### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Install magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Format
         run: nix develop -c go fmt
       - name: Check diff
@@ -32,6 +34,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
+    - name: Install magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
       with:
         # We don't _actually_ have kvm on the actions runners, so this
         # will use TCG (CPU emulation) and thus be a fair bit
@@ -49,6 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check Spelling
         run: nix develop --command codespell --ignore-words-list crate,pullrequest,pullrequests --skip target .
 
@@ -58,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check nixpkgs-fmt formatting
         run: git ls-files '*.nix' | nix develop --command xargs nixpkgs-fmt --check
 
@@ -66,5 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check EditorConfig conformance
         run: nix develop --command eclint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
-    - name: Install magic Nix cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
       with:
         # We don't _actually_ have kvm on the actions runners, so this
         # will use TCG (CPU emulation) and thus be a fair bit
@@ -43,6 +41,8 @@ jobs:
         # running fast.
         extra-conf: |
           extra-system-features = kvm
+    - name: Install magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build -L
     - name: Test


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
