### PR TITLE
Make the MAC detection more resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ You should only use this if:
 
 - You still need these clients to have stable IP addresses, even if they don't keep any state (frequent OS wipes!)
 
-
-We use this for macs where reprovisioning isn't 100% reliable, so we want them to get the same IP address even if _none of the scripts have run_.
+We use this for macOS where reprovisioning isn't 100% reliable, so we want them to get the same IP address even if _none of the scripts have run_.
 This is why we wrote this horrible hack.
 
+Note: this daemon may or may not work correctly with relay agent forwarding.
 
 ## Usage
 
@@ -29,6 +29,9 @@ See the `flake.nix` for a NixOS test involving router and a client.
 
 The prefix is assumed to be at least a /80.
 The MAC address is simply concatenated onto the prefix.
+
+If the DHCPv6 Solicit request does not have a MAC address, we fall back to loading the MAC from an eui64 link-local IP.
+Note that this only works if the Soliciting system encodes their MAC in their link local address via EUI-64 (privacy/stable-privacy LLAs won’t work.)
 
 ## What's not inside
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
             #vendorSha256 = pkgs.lib.fakeSha256;
 
             goSum = ./go.sum;
-            vendorHash = "sha256-K/X0/kNqVhBRm2LjOdZOHUu7FONuMJmCnKgFZghyMXM=";
+            vendorHash = "sha256-i7Cs1LdU7Juge77WaIaAdIAdjc2lfr9IALleGO3MaPI=";
           };
         });
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.23.0
 
 toolchain go1.23.8
 
-require github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2
+require (
+	github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2
+	github.com/mdlayher/netx v0.0.0-20230430222610-7e21880baee8
+)
 
 require (
 	github.com/josharian/native v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2/go.mod h1:3A9PQ1
 github.com/josharian/native v1.0.1-0.20221213033349-c1e37c09b531/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
+github.com/mdlayher/netx v0.0.0-20230430222610-7e21880baee8 h1:HMgSn3c16SXca3M+n6fLK2hXJLd4mhKAsZZh7lQfYmQ=
+github.com/mdlayher/netx v0.0.0-20230430222610-7e21880baee8/go.mod h1:qhZhwMDNWwZglKfwuWm0U9pCr/YKX1QAEwwJk9qfiTQ=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.19 h1:tYLzDnjDXh9qIxSTKHwXwOYmm9d887Y7Y1ZkyXYHAN4=
 github.com/pierrec/lz4/v4 v4.1.19/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=


### PR DESCRIPTION
The original code only fetched the MAC from the message.
The way I understand it, DHCPv6 requests focus on the DUID as the identifier, NOT the MAC.
This is especially true if the client is requesting a temporary or private IP address.

This change falls back to trying to extract the IP address of the peer we're talking to.
It'll be a link local address which starts with fe80:.

Sometimes, that link-local address is generated as an EUI64 IPv6 address which encodes the device's MAC address.
This isn't universally true: sometimes devices will deliberately not expose an EUI64 address for privacy reasons.
However, we can detect that case as eui64 IPs have 0xFFFE tucked in the middle of the MAC.

Anyway, if we can extract a MAC from the eui64 IP from the peer, we use that as their MAC.

Note that I don't believe this will work if we have Relay Agent forwarding in our network.
We don't right now, so ... that is a thing to watch out for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Better DHCPv6 client identification: if a request lacks a MAC, the server falls back to deriving it from the peer’s link-local address, reducing missed clients.
  - Improved peer-related error messages to aid troubleshooting.

- Documentation
  - Clarified macOS usage note and warned about possible relay-agent incompatibility.
  - Documented the fallback MAC-from-peer behavior and its EUI-64 limitation.

- Chores
  - Updated dependencies and refreshed build/vendor hash for reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->