### PR TITLE
Ack that releasing an IP was successfully 

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,6 +173,12 @@ func (s *DHCPv6Handler) process(msg *dhcpv6.Message,
 		dhcpv6.MessageTypeRebind:
 
 		break
+	case dhcpv6.MessageTypeRelease:
+		resp.AddOption(&dhcpv6.OptStatusCode{
+			StatusCode:    iana.StatusSuccess,
+			StatusMessage: "success",
+		})
+		return
 	default:
 		err = fmt.Errorf("DHCPv6 ignore message type %s", msg.Type())
 		return


### PR DESCRIPTION
Otherwise clients just keep trying to give up the IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DHCPv6 Release messages now receive an explicit success acknowledgment, improving protocol compliance and client interoperability. This prevents releases from being silently ignored, reduces unnecessary processing, and can eliminate client-side retries or timeouts when releasing addresses.
  * Provides faster, clearer lease release behavior, aiding smoother network transitions and reducing unnecessary log noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->