### PR TITLE
Provide recursive DNS if they want it

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,6 +260,10 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 		resp.AddOption(fqdn)
 	}
 
+	if msg.IsOptionRequested(dhcpv6.OptionDNSRecursiveNameServer) {
+		dhcpv6.WithDNS(net.ParseIP("2606:4700:4700::1111"), net.ParseIP("2001:4860:4860::8888"))(resp)
+	}
+
 	resp.AddOption(&dhcpv6.OptStatusCode{
 		StatusCode:    iana.StatusSuccess,
 		StatusMessage: "success",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DHCPv6 responses now include IPv6 DNS servers when requested, enabling automatic name resolution without manual configuration.
  * Default DNS servers provided: 2606:4700:4700::1111 and 2001:4860:4860::8888.
  * Applied conditionally only when clients request DNS via DHCPv6, improving out-of-the-box connectivity and reducing setup steps for compliant clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->