### PR TITLE
Serve http boot URLs if requested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check Spelling
         if: ${{ success() || failure() }}
-        run: nix develop --command codespell --ignore-words-list crate,pullrequest,pullrequests --skip target .
+        run: nix develop --command codespell --ignore-words-list crate,pullrequest,pullrequests,ArchTypes --skip target .
 
       - name: Check nixpkgs-fmt formatting
         if: ${{ success() || failure() }}

--- a/README.md
+++ b/README.md
@@ -9,16 +9,31 @@ You should only use this if:
 
 - You still need these clients to have stable IP addresses, even if they don't keep any state (frequent OS wipes!)
 
-We use this for macOS where reprovisioning isn't 100% reliable, so we want them to get the same IP address even if _none of the scripts have run_.
-This is why we wrote this horrible hack.
+We use this for macOS and a HITL where reprovisioning isn't 100% reliable, so we want them to get the same IP address even if _none of the scripts have run_.
 
-Note: this daemon may or may not work correctly with relay agent forwarding.
+Notes:
+
+- this daemon may or may not work correctly with relay agent forwarding.
+- this daemon will not try to issue HTTP Boot instructions if the template is an empty string.
+  If you don't want that, feel free to PR it into an optional setting.
 
 ## Usage
 
-```
+```sh
 go build .
-sudo ./dhcpv6macd -interface enp2s0 -base-address 2001:db8:0123:4567::
+sudo ./dhcpv6macd -interface enp2s0 -base-address 2001:db8:0123:4567:: -http-boot-url-template 'http://netboot.target/?mac={{.MAC}}'
+```
+
+...where the template can use these parameters:
+
+- `MAC` -- the MAC address of the netbooting device
+- `BaseAddress` -- the same value as passed in the CLI arguments
+- `Payload` -- a base64 encoded JSON blob about the booting device, for example `eyJhcmNoaXRlY3R1cmVzIjpbIkVGSSB4ODYtNjQgYm9vdCBmcm9tIEhUVFAiXX0=` which is decodes to:
+
+```json
+{
+  "architectures": ["EFI x86-64 boot from HTTP"]
+}
 ```
 
 There is also a NixOS module in the flake.nix.

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,13 @@
                   The MAC address is simply concatenated onto the prefix.
                 '';
               };
+              httpBootUrlTemplate = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = lib.mdDoc ''
+                  `http://[{{.BaseAddress}}]/?mac={{.MAC}}&payload={{.Payload}}`
+                '';
+              };
             };
           };
           config = let cfg = config.services.detsys.dhcpv6macd; in lib.mkIf cfg.enable {
@@ -116,6 +123,8 @@
                   cfg.interface
                   "-base-address"
                   cfg.baseAddress
+                  "-http-boot-url-template"
+                  cfg.httpBootUrlTemplate
                 ]);
               };
             };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added HTTP boot URL templating for boot requests, enabling dynamic boot URLs based on client details.
  - Introduced a new CLI flag to set the HTTP boot URL template.
  - Exposed a corresponding configuration option in the NixOS module.

- Documentation
  - Updated README with the new usage flag, template parameters (MAC, BaseAddress, Payload), and examples (including base64-encoded payload and supported architectures).
  - Clarified notes and reorganized guidance for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->