### PR TITLE
Grahamc/more robust events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@main
         if: ${{ success() || failure() }}
 
+      - run: touch ipxe.efi
+
       - name: Go Formatting
         if: ${{ success() || failure() }}
         run: nix develop -c go fmt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dhcpv6macd
 result
+.scratch

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dhcpv6macd
 result
 .scratch
+ipxe.efi

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ data: {"01:01:01:01:01:01":{"Mac":"01:01:01:01:01:01","Events":[{"event":"init",
 Or if you specified a MAC to filter on, it'll return the object directly (or `null` if the mac isn't present in the event table):
 
 ```
-data: {"Mac":"01:01:01:01:01:01","Events":[{"event":"init","timestamp":"2025-10-13T20:01:16.698695404Z"},{"event":"point_pxe_to_ipxe_over_tftp","timestamp":"2025-10-13T20:01:16.699618993Z"},{"event":"served_ipxe_over_tftp","timestamp":"2025-10-13T20:01:22.946541642Z"},{"event":"point_ipxe_to_http_boot","timestamp":"2025-10-13T20:01:30.972207315Z"},{"event":"os_init","timestamp":"2025-10-13T20:01:50.065743799Z"}]}
+data: {"Mac":"01:01:01:01:01:01","Events":[{"event":"init","timestamp":"2025-10-13T20:01:16.698695404Z"},{"event":"point_pxe_to_ipxe_over_tftp","timestamp":"2025-10-13T20:01:16.699618993Z"},{"event":"serve_ipxe_over_tftp","timestamp":"2025-10-13T20:01:22.946541642Z"},{"event":"point_ipxe_to_http_boot","timestamp":"2025-10-13T20:01:30.972207315Z"},{"event":"os_init","timestamp":"2025-10-13T20:01:50.065743799Z"}]}
 ```
 
 Then, events will be served as they arrive:
@@ -84,7 +84,7 @@ data: {"mac":"01:01:01:01:01:01","event":{"event":"init","timestamp":"2025-10-13
 
 data: {"mac":"01:01:01:01:01:01","event":{"event":"point_pxe_to_ipxe_over_tftp","timestamp":"2025-10-13T20:01:16.699634041Z"}}
 
-data: {"mac":"01:01:01:01:01:01","event":{"event":"served_ipxe_over_tftp","timestamp":"2025-10-13T20:01:22.946572526Z"}}
+data: {"mac":"01:01:01:01:01:01","event":{"event":"serve_ipxe_over_tftp","timestamp":"2025-10-13T20:01:22.946572526Z"}}
 ```
 
 ### Root certificate tweaking

--- a/broker.go
+++ b/broker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"sync"
 )
 
@@ -26,6 +27,7 @@ func (b *Broker) Subscribe() (ch chan IdentifiedEvent, unsubscribe func()) {
 	}
 }
 func (b *Broker) Publish(msg IdentifiedEvent) {
+	log.Println("New event", msg)
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	for ch := range b.clients {

--- a/broker.go
+++ b/broker.go
@@ -31,7 +31,7 @@ func (b *Broker) Subscribe() (ch chan IdentifiedEvent, unsubscribe func()) {
 func (b *Broker) PublishFyi(msg string) {
 	b.Publish(IdentifiedEvent{
 		Mac:   nil,
-		Event: NewEvent("fyi", false, []interface{}{msg}),
+		Event: NewEvent("fyi", false, msg),
 	})
 }
 

--- a/broker.go
+++ b/broker.go
@@ -39,8 +39,10 @@ func (b *Broker) Publish(msg IdentifiedEvent) {
 	evbytes, err := json.Marshal(msg)
 	if err != nil {
 		log.Println("JSON marshal failure of a published IdentifiedEvent", err)
+	} else {
+		log.Println("Event", string(evbytes))
 	}
-	log.Println("Event", string(evbytes))
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	for ch := range b.clients {

--- a/broker.go
+++ b/broker.go
@@ -26,6 +26,14 @@ func (b *Broker) Subscribe() (ch chan IdentifiedEvent, unsubscribe func()) {
 		close(ch)
 	}
 }
+
+func (b *Broker) PublishFyi(msg string) {
+	b.Publish(IdentifiedEvent{
+		Mac:   nil,
+		Event: NewEvent("fyi", false, []interface{}{msg}),
+	})
+}
+
 func (b *Broker) Publish(msg IdentifiedEvent) {
 	log.Println("New event", msg)
 	b.mu.RLock()

--- a/broker.go
+++ b/broker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"sync"
 )
@@ -35,7 +36,11 @@ func (b *Broker) PublishFyi(msg string) {
 }
 
 func (b *Broker) Publish(msg IdentifiedEvent) {
-	log.Println("New event", msg)
+	evbytes, err := json.Marshal(msg)
+	if err != nil {
+		log.Println("JSON marshal failure of a published IdentifiedEvent", err)
+	}
+	log.Println("Event", string(evbytes))
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	for ch := range b.clients {

--- a/flake.nix
+++ b/flake.nix
@@ -56,9 +56,9 @@
         in
         {
           iPXE = pkgsX8664Linux.ipxe.overrideAttrs (oldAttrs: {
-              patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
-                ++ iPxePatches;
-            });
+            patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
+              ++ iPxePatches;
+          });
 
           default = pkgs.buildGoModule {
             pname = "dhcpv6macd";

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
                   go
                   go-tools
                   nixpkgs-fmt
+                  just
                 ];
               };
           });

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,11 @@
           pkgsX8664Linux = nixpkgsFor.x86_64-linux;
         in
         {
+          iPXE = pkgsX8664Linux.ipxe.overrideAttrs (oldAttrs: {
+              patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
+                ++ iPxePatches;
+            });
+
           default = pkgs.buildGoModule {
             pname = "dhcpv6macd";
             inherit version;
@@ -68,10 +73,7 @@
               ];
             };
 
-            PXE = pkgsX8664Linux.ipxe.overrideAttrs (oldAttrs: {
-              patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
-                ++ iPxePatches;
-            });
+            PXE = self.packages.x86_64-linux.iPXE;
 
             postPatch = ''
               if [ -f ./ipxe.efi ]; then

--- a/http.go
+++ b/http.go
@@ -36,7 +36,6 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 			}
 
 			name := path.Clean(path.Join(netbootDir, mac.String(), "boot.efi"))
-			log.Println("?", name)
 
 			if !strings.HasPrefix(name, netbootDir+"/") {
 				log.Println("Path did not clean to subordinate of", netbootDir)

--- a/http.go
+++ b/http.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -49,7 +56,6 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 	} else if _, err := os.Stat(netbootDir); os.IsNotExist(err) {
 		log.Printf("netboot directory does not exist, will not serve it: %s", netbootDir)
 	} else {
-		fs := http.FileServer(neuteredFileSystem{http.Dir(netbootDir)})
 		server.HandleFunc("/mac/{mac_addr}/boot.efi", func(w http.ResponseWriter, r *http.Request) {
 			// Extract MAC address from path
 			macStr := r.PathValue("mac_addr")
@@ -58,16 +64,71 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 				log.Printf("Got request with something that didn't look like a MAC address. Returning 404.")
 				http.NotFound(w, r)
 				return
-			} else {
-				machine := m.GetOrInitMachine(mac)
-
-				// Trigger state transition to http_fetch_uki
-				if err := machine.Event(r.Context(), "http_fetch_uki"); err != nil {
-					log.Printf("Failed to transition to http_fetch_uki for %s: %v", macStr, err)
-				}
 			}
 
-			http.StripPrefix("/mac/", fs).ServeHTTP(w, r)
+			name := path.Clean(path.Join(netbootDir, mac.String(), "boot.efi"))
+			log.Println("?", name)
+
+			if !strings.HasPrefix(name, netbootDir+"/") {
+				log.Println("Path did not clean to subordinate of", netbootDir)
+				http.Error(w, "fishy path", 400)
+				return
+			}
+
+			f, err := os.Open(name)
+			if err != nil {
+				msg, code := toHTTPError(err)
+				http.Error(w, msg, code)
+				return
+			}
+			defer f.Close()
+
+			stat, err := f.Stat()
+			if err != nil {
+				msg, code := toHTTPError(err)
+				http.Error(w, msg, code)
+				return
+			}
+
+			if stat.IsDir() {
+				http.Error(w, "boot.efi was a directory", 500)
+				return
+			}
+
+			w.Header().Set("Content-Length", strconv.FormatInt(stat.Size(), 10))
+			w.Header().Set("Content-Type", "application/octet-stream")
+
+			machine := m.GetOrInitMachine(mac)
+
+			event := TransferEvent{
+				Filename:   name,
+				State:      "init",
+				TotalBytes: stat.Size(),
+			}
+
+			// Trigger state transition to http_fetch_uki
+			if err := machine.Event(r.Context(), "http_fetch_uki", event); err != nil {
+				log.Printf("Failed to transition to http_fetch_uki for %s: %v", macStr, err)
+			}
+
+			event.State = "sending"
+
+			reader := newProgressReader(f, func(bytes int64) error {
+				event.SentBytes = bytes
+				machine.Event(context.Background(), "http_fetch_uki", event)
+				return nil
+			})
+
+			_, err = io.Copy(w, reader)
+
+			if err != nil {
+				event.Error = err
+				machine.Event(context.Background(), "http_fetch_uki", event)
+				log.Printf("Serving failure: %v", err)
+			} else {
+				event.State = "complete"
+				machine.Event(context.Background(), "http_fetch_uki", event)
+			}
 		})
 	}
 
@@ -161,4 +222,23 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 	})
 
 	return server, nil
+}
+
+// Following was lifted from net/http:
+//
+// toHTTPError returns a non-specific HTTP error message and status code
+// for a given non-nil error value. It's important that toHTTPError does not
+// actually return err.Error(), since msg and httpStatus are returned to users,
+// and historically Go's ServeContent always returned just "404 Not Found" for
+// all errors. We don't want to start leaking information in error messages.
+func toHTTPError(err error) (msg string, httpStatus int) {
+	if errors.Is(err, fs.ErrNotExist) {
+		return "404 page not found", http.StatusNotFound
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return "403 Forbidden", http.StatusForbidden
+	}
+
+	// Default:
+	return "500 Internal Server Error", http.StatusInternalServerError
 }

--- a/http.go
+++ b/http.go
@@ -12,41 +12,10 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 )
-
-type neuteredFileSystem struct {
-	fs http.FileSystem
-}
-
-func (nfs neuteredFileSystem) Open(path string) (http.File, error) {
-	f, err := nfs.fs.Open(path)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	if s.IsDir() {
-		index := filepath.Join(path, "index.html")
-		if _, err := nfs.fs.Open(index); err != nil {
-			closeErr := f.Close()
-			if closeErr != nil {
-				return nil, closeErr
-			}
-
-			return nil, err
-		}
-	}
-
-	return f, nil
-}
 
 func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error) {
 	server := http.NewServeMux()

--- a/http.go
+++ b/http.go
@@ -212,7 +212,7 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 					return
 				}
 
-				if macStr == "" || msg.Mac.String() == mac.String() {
+				if macStr == "" || msg.Mac.String() == "" || msg.Mac.String() == mac.String() {
 					data, err := json.Marshal(msg)
 					if err != nil {
 						log.Println("JSON marshalling error: ", err)

--- a/http.go
+++ b/http.go
@@ -129,7 +129,7 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 
 			if err != nil {
 				event.State = "error"
-				event.Error = err
+				event.Error = err.Error()
 				machine.Event(context.Background(), "http_fetch_uki", event)
 				log.Printf("Serving failure: %v", err)
 			} else {

--- a/http.go
+++ b/http.go
@@ -128,6 +128,7 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 			_, err = io.Copy(w, reader)
 
 			if err != nil {
+				event.State = "error"
 				event.Error = err
 				machine.Event(context.Background(), "http_fetch_uki", event)
 				log.Printf("Serving failure: %v", err)

--- a/http.go
+++ b/http.go
@@ -106,6 +106,12 @@ func webserver(netbootDir string, b *Broker, m *Machines) (*http.ServeMux, error
 				TotalBytes: stat.Size(),
 			}
 
+			if r.TLS == nil {
+				event.Protocol = "http"
+			} else {
+				event.Protocol = "https"
+			}
+
 			// Trigger state transition to http_fetch_uki
 			if err := machine.Event(r.Context(), "http_fetch_uki", event); err != nil {
 				log.Printf("Failed to transition to http_fetch_uki for %s: %v", macStr, err)

--- a/justfile
+++ b/justfile
@@ -36,7 +36,6 @@ make-cert: make-scratch
             -out "{{scratch}}/tls.crt" \
             -sha256 \
             -days 1 \
-            -nodes \
             -subj "/CN=dhcpv6macd"
     else
         echo "scratch TLS key/cert: not recreating them because they exist already"

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ make-samples: make-scratch
     mkdir -p "{{scratch}}/samples/00:00:00:00:00:00"
     cd "{{scratch}}/samples/00:00:00:00:00:00"
     if [ ! -e "boot.efi" ]; then
-        yes "dhcpv6macd is a choice" | head --bytes=50MB > boot.efi
+        yes "dhcpv6macd is a choice" | head -c 52428800 > boot.efi
     else
         echo "00:00:00:00:00:00 sample: not creating it because it already exists"
     fi

--- a/justfile
+++ b/justfile
@@ -1,10 +1,11 @@
 interface := "en0"
 ip := "127.0.0.1"
+repo_root := justfile_directory()
 scratch := justfile_directory() + "/.scratch"
+ipxe_result_link := scratch + "/ipxe-result"
 
 
-
-run: make-samples make-cert
+run: make-pxe-efi make-cert make-samples
     go run . \
         -interface "{{interface}}" \
         -netboot-dir "{{scratch}}/samples" \
@@ -15,6 +16,15 @@ run: make-samples make-cert
         -https-listen-addr "{{ip}}:20443" \
         -tftp-listen-addr "{{ip}}:20069"
 
+make-pxe-efi: make-scratch
+    #!/bin/sh
+    if [ ! -e "{{ipxe_result_link}}/ipxe.efi" ]; then
+        nix build .#iPXE --out-link "{{ipxe_result_link}}"
+    else
+        echo "ipxe.efi: not re-building since it already exists in .scratch"
+    fi
+
+    cat "{{ipxe_result_link}}/ipxe.efi" > "{{repo_root}}/ipxe.efi"
 
 make-cert: make-scratch
     #!/bin/sh

--- a/justfile
+++ b/justfile
@@ -24,6 +24,7 @@ make-pxe-efi: make-scratch
         echo "ipxe.efi: not re-building since it already exists in .scratch"
     fi
 
+    # using cat so we own the file and mtime is correct, etc.
     cat "{{ipxe_result_link}}/ipxe.efi" > "{{repo_root}}/ipxe.efi"
 
 make-cert: make-scratch

--- a/justfile
+++ b/justfile
@@ -1,0 +1,43 @@
+interface := "en0"
+ip := "127.0.0.1"
+scratch := justfile_directory() + "/.scratch"
+
+
+
+run: make-samples make-cert
+    go run . \
+        -interface "{{interface}}" \
+        -netboot-dir "{{scratch}}/samples" \
+        -tls-cert-file "{{scratch}}/tls.crt" \
+        -tls-key-file "{{scratch}}/tls.key" \
+
+
+make-cert: make-scratch
+    #!/bin/sh
+    if [ ! -e "{{scratch}}/tls.key" ] || [ ! -e "{{scratch}}/tls.crt" ]; then
+        openssl req -x509 \
+            -newkey rsa:4096 \
+            -nodes \
+            -keyout "{{scratch}}/tls.key" \
+            -out "{{scratch}}/tls.crt" \
+            -sha256 \
+            -days 1 \
+            -nodes \
+            -subj "/CN=dhcpv6macd"
+    else
+        echo "scratch TLS key/cert: not recreating them because they exist already"
+    fi
+
+
+make-samples: make-scratch
+    #!/bin/sh
+    mkdir -p "{{scratch}}/samples/00:00:00:00:00:00"
+    cd "{{scratch}}/samples/00:00:00:00:00:00"
+    if [ ! -e "boot.efi" ]; then
+        yes "dhcpv6macd is a choice" | head --bytes=50MB > boot.efi
+    else
+        echo "00:00:00:00:00:00 sample: not creating it because it already exists"
+    fi
+
+make-scratch:
+    mkdir -p "{{scratch}}"

--- a/justfile
+++ b/justfile
@@ -10,6 +10,10 @@ run: make-samples make-cert
         -netboot-dir "{{scratch}}/samples" \
         -tls-cert-file "{{scratch}}/tls.crt" \
         -tls-key-file "{{scratch}}/tls.key" \
+        -dhcpv6-listen-port 20547 \
+        -http-listen-addr "{{ip}}:20080" \
+        -https-listen-addr "{{ip}}:20443" \
+        -tftp-listen-addr "{{ip}}:20069"
 
 
 make-cert: make-scratch

--- a/log_events.go
+++ b/log_events.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"io"
+)
+
+type FyiHookWriter struct {
+	w      io.Writer
+	copyTo func(msg string)
+}
+
+func (h *FyiHookWriter) Write(p []byte) (int, error) {
+	h.copyTo(string(p))
+	return h.w.Write(p)
+}

--- a/log_events.go
+++ b/log_events.go
@@ -10,6 +10,13 @@ type FyiHookWriter struct {
 }
 
 func (h *FyiHookWriter) Write(p []byte) (int, error) {
-	h.copyTo(string(p))
+	if h.copyTo != nil {
+		h.copyTo(string(p))
+	}
+
+	if h.w == nil {
+		return len(p), nil
+	}
+
 	return h.w.Write(p)
 }

--- a/machine.go
+++ b/machine.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"net"
 	"sync"
 	"time"

--- a/machine.go
+++ b/machine.go
@@ -156,6 +156,12 @@ func NewMachine(mac net.HardwareAddr, broker *Broker) *Machine {
 	return &machine
 }
 
+func (m *Machine) SetIPv6Address(ip net.IP) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.IPv6Address = ip
+}
+
 func (m *Machine) Can(event string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/machine.go
+++ b/machine.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -70,6 +71,8 @@ type IdentifiedEvent struct {
 type Event struct {
 	Event     string `json:"event"`
 	Timestamp string `json:"timestamp"`
+	Repeated  bool   `json:"repeat_event"`
+	Arguments []interface{}
 }
 
 var bogusTimestamp *string
@@ -87,9 +90,11 @@ func (m MAC) String() string {
 	return net.HardwareAddr(m).String()
 }
 
-func NewEvent(event string) Event {
+func NewEvent(event string, repeat bool, args []interface{}) Event {
 	ev := Event{
-		Event: event,
+		Event:     event,
+		Repeated:  repeat,
+		Arguments: args,
 	}
 
 	if bogusTimestamp == nil {
@@ -125,12 +130,12 @@ func NewMachine(mac net.HardwareAddr, broker *Broker) *Machine {
 		},
 		fsm.Callbacks{
 			"enter_state": func(_ context.Context, e *fsm.Event) {
-				machine.Events.Push(NewEvent(e.Dst))
+				machine.Events.Push(NewEvent(e.Dst, false, e.Args))
 			},
 		},
 	)
 
-	init := NewEvent("init")
+	init := NewEvent("init", false, nil)
 	machine.Events.Push(init)
 	broker.Publish(IdentifiedEvent{
 		Mac:   MAC(mac),
@@ -155,28 +160,38 @@ func (m *Machine) Cannot(event string) bool {
 func (m *Machine) Event(ctx context.Context, event string, args ...interface{}) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	var repeat bool
+
 	if m.fsm.Is(event) {
-		// Emulate the FSM always allowing an event to transition into itself
-		return nil
+		repeat = true
+	} else {
+		repeat = false
 	}
 
-	if m.fsm.Cannot(event) {
-		m.resetToWithoutLocking(event)
+	identifiedEvent := IdentifiedEvent{
+		Mac:   m.Mac,
+		Event: NewEvent(event, repeat, args),
+	}
+
+	if repeat {
+		// Emulate the FSM always allowing an event to transition into itself
+		m.broker.Publish(identifiedEvent)
+		return nil
+	} else if m.fsm.Cannot(event) {
+		m.resetToWithoutLocking(event, args)
 		return nil
 	} else {
 		err := m.fsm.Event(ctx, event, args...)
 		if err == nil {
-			m.broker.Publish(IdentifiedEvent{
-				Mac:   m.Mac,
-				Event: NewEvent(event),
-			})
+			m.broker.Publish(identifiedEvent)
 		}
 		return err
 	}
 }
 
-func (m *Machine) resetToWithoutLocking(event string) {
-	jump := NewEvent("jump_to")
+func (m *Machine) resetToWithoutLocking(event string, args []interface{}) {
+	jump := NewEvent("jump_to", false, nil)
 	m.Events.Push(jump)
 
 	m.broker.Publish(IdentifiedEvent{
@@ -186,7 +201,7 @@ func (m *Machine) resetToWithoutLocking(event string) {
 
 	m.fsm.SetState(event)
 
-	ev := NewEvent(event)
+	ev := NewEvent(event, false, args)
 	m.Events.Push(ev)
 
 	m.broker.Publish(IdentifiedEvent{

--- a/machine.go
+++ b/machine.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -68,10 +69,10 @@ type IdentifiedEvent struct {
 }
 
 type Event struct {
-	Event     string        `json:"event"`
-	Timestamp string        `json:"timestamp"`
-	Repeated  bool          `json:"repeat_event"`
-	Arguments []interface{} `json:"arguments"`
+	Event     string      `json:"event"`
+	Timestamp string      `json:"timestamp"`
+	Repeated  bool        `json:"repeat_event"`
+	Detail    interface{} `json:"detail"`
 }
 
 var bogusTimestamp *string
@@ -89,11 +90,11 @@ func (m MAC) String() string {
 	return net.HardwareAddr(m).String()
 }
 
-func NewEvent(event string, repeat bool, args []interface{}) Event {
+func NewEvent(event string, repeat bool, detail interface{}) Event {
 	ev := Event{
-		Event:     event,
-		Repeated:  repeat,
-		Arguments: args,
+		Event:    event,
+		Repeated: repeat,
+		Detail:   detail,
 	}
 
 	if bogusTimestamp == nil {
@@ -129,7 +130,16 @@ func NewMachine(mac net.HardwareAddr, broker *Broker) *Machine {
 		},
 		fsm.Callbacks{
 			"enter_state": func(_ context.Context, e *fsm.Event) {
-				machine.Events.Push(NewEvent(e.Dst, false, e.Args))
+				var arg interface{}
+				if len(e.Args) == 0 {
+					arg = nil
+				} else if len(e.Args) == 1 {
+					arg = e.Args[0]
+				} else {
+					log.Println("Entered a state where the event had plural arguments", machine.Mac, e)
+					arg = e.Args
+				}
+				machine.Events.Push(NewEvent(e.Dst, false, arg))
 			},
 		},
 	)
@@ -156,7 +166,7 @@ func (m *Machine) Cannot(event string) bool {
 	return m.fsm.Cannot(event)
 }
 
-func (m *Machine) Event(ctx context.Context, event string, args ...interface{}) error {
+func (m *Machine) Event(ctx context.Context, event string, detail interface{}) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -170,7 +180,7 @@ func (m *Machine) Event(ctx context.Context, event string, args ...interface{}) 
 
 	identifiedEvent := IdentifiedEvent{
 		Mac:   m.Mac,
-		Event: NewEvent(event, repeat, args),
+		Event: NewEvent(event, repeat, detail),
 	}
 
 	if repeat {
@@ -178,10 +188,10 @@ func (m *Machine) Event(ctx context.Context, event string, args ...interface{}) 
 		m.broker.Publish(identifiedEvent)
 		return nil
 	} else if m.fsm.Cannot(event) {
-		m.resetToWithoutLocking(event, args)
+		m.resetToWithoutLocking(event, detail)
 		return nil
 	} else {
-		err := m.fsm.Event(ctx, event, args...)
+		err := m.fsm.Event(ctx, event, detail)
 		if err == nil {
 			m.broker.Publish(identifiedEvent)
 		}
@@ -189,7 +199,7 @@ func (m *Machine) Event(ctx context.Context, event string, args ...interface{}) 
 	}
 }
 
-func (m *Machine) resetToWithoutLocking(event string, args []interface{}) {
+func (m *Machine) resetToWithoutLocking(event string, detail interface{}) {
 	jump := NewEvent("jump_to", false, nil)
 	m.Events.Push(jump)
 
@@ -200,7 +210,7 @@ func (m *Machine) resetToWithoutLocking(event string, args []interface{}) {
 
 	m.fsm.SetState(event)
 
-	ev := NewEvent(event, false, args)
+	ev := NewEvent(event, false, detail)
 	m.Events.Push(ev)
 
 	m.broker.Publish(IdentifiedEvent{

--- a/machine.go
+++ b/machine.go
@@ -53,19 +53,21 @@ func (m *Machines) MarshalJSON() ([]byte, error) {
 }
 
 type Machine struct {
-	mu     sync.RWMutex
-	Mac    MAC
-	fsm    *fsm.FSM
-	Events *Ring[Event]
-	broker *Broker
+	mu          sync.RWMutex
+	Mac         MAC
+	IPv6Address net.IP
+	fsm         *fsm.FSM
+	Events      *Ring[Event]
+	broker      *Broker
 }
 
 type MAC net.HardwareAddr
 type MACKey string
 
 type IdentifiedEvent struct {
-	Mac   MAC   `json:"mac"`
-	Event Event `json:"event"`
+	Mac         MAC    `json:"mac"`
+	IPv6Address net.IP `json:"ipv6_address"`
+	Event       Event  `json:"event"`
 }
 
 type Event struct {
@@ -179,8 +181,9 @@ func (m *Machine) Event(ctx context.Context, event string, detail interface{}) e
 	}
 
 	identifiedEvent := IdentifiedEvent{
-		Mac:   m.Mac,
-		Event: NewEvent(event, repeat, detail),
+		Mac:         m.Mac,
+		IPv6Address: m.IPv6Address,
+		Event:       NewEvent(event, repeat, detail),
 	}
 
 	if repeat {
@@ -204,8 +207,9 @@ func (m *Machine) resetToWithoutLocking(event string, detail interface{}) {
 	m.Events.Push(jump)
 
 	m.broker.Publish(IdentifiedEvent{
-		Mac:   m.Mac,
-		Event: jump,
+		Mac:         m.Mac,
+		IPv6Address: m.IPv6Address,
+		Event:       jump,
 	})
 
 	m.fsm.SetState(event)
@@ -214,7 +218,8 @@ func (m *Machine) resetToWithoutLocking(event string, detail interface{}) {
 	m.Events.Push(ev)
 
 	m.broker.Publish(IdentifiedEvent{
-		Mac:   m.Mac,
-		Event: ev,
+		Mac:         m.Mac,
+		IPv6Address: m.IPv6Address,
+		Event:       ev,
 	})
 }

--- a/machine.go
+++ b/machine.go
@@ -121,8 +121,8 @@ func NewMachine(mac net.HardwareAddr, broker *Broker) *Machine {
 			{Name: "http_boot", Src: []string{"firmware_init", "reset"}, Dst: "http_boot"},
 
 			{Name: "point_pxe_to_ipxe_over_tftp", Src: []string{"firmware_init", "reset"}, Dst: "point_pxe_to_ipxe_over_tftp"},
-			{Name: "served_ipxe_over_tftp", Src: []string{"point_pxe_to_ipxe_over_tftp"}, Dst: "served_ipxe_over_tftp"},
-			{Name: "point_ipxe_to_http_boot", Src: []string{"served_ipxe_over_tftp"}, Dst: "point_ipxe_to_http_boot"},
+			{Name: "serve_ipxe_over_tftp", Src: []string{"point_pxe_to_ipxe_over_tftp"}, Dst: "serve_ipxe_over_tftp"},
+			{Name: "point_ipxe_to_http_boot", Src: []string{"serve_ipxe_over_tftp"}, Dst: "point_ipxe_to_http_boot"},
 
 			{Name: "http_fetch_uki", Src: []string{"http_boot", "point_ipxe_to_http_boot"}, Dst: "http_fetch_uki"},
 

--- a/machine.go
+++ b/machine.go
@@ -178,13 +178,7 @@ func (m *Machine) Event(ctx context.Context, event string, detail interface{}) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var repeat bool
-
-	if m.fsm.Is(event) {
-		repeat = true
-	} else {
-		repeat = false
-	}
+	repeat := m.fsm.Is(event)
 
 	identifiedEvent := IdentifiedEvent{
 		Mac:         m.Mac,

--- a/machine.go
+++ b/machine.go
@@ -68,10 +68,10 @@ type IdentifiedEvent struct {
 }
 
 type Event struct {
-	Event     string `json:"event"`
-	Timestamp string `json:"timestamp"`
-	Repeated  bool   `json:"repeat_event"`
-	Arguments []interface{}
+	Event     string        `json:"event"`
+	Timestamp string        `json:"timestamp"`
+	Repeated  bool          `json:"repeat_event"`
+	Arguments []interface{} `json:"arguments"`
 }
 
 var bogusTimestamp *string

--- a/machine_test.go
+++ b/machine_test.go
@@ -111,10 +111,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "served_ipxe_over_tftp")
-		expectEvent(t, subscriber, "served_ipxe_over_tftp")
+		machine.Event(context.Background(), "serve_ipxe_over_tftp")
+		expectEvent(t, subscriber, "serve_ipxe_over_tftp")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {served_ipxe_over_tftp bogustime}]"
+		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}
@@ -124,7 +124,7 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "point_ipxe_to_http_boot")
 		expectEvent(t, subscriber, "point_ipxe_to_http_boot")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {served_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime}]"
+		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}
@@ -134,7 +134,7 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "http_fetch_uki")
 		expectEvent(t, subscriber, "http_fetch_uki")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {served_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime}]"
+		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}
@@ -144,7 +144,7 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "os_init")
 		expectEvent(t, subscriber, "os_init")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {served_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
+		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}
@@ -154,7 +154,7 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "os_init")
 		expectNoEvent(t, subscriber)
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {served_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
+		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}
@@ -183,14 +183,14 @@ func TestTransitionsJumpTo(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "served_ipxe_over_tftp")
+		machine.Event(context.Background(), "serve_ipxe_over_tftp")
 		expectEvent(t, subscriber, "jump_to")
 
-		expectEvent(t, subscriber, "served_ipxe_over_tftp")
+		expectEvent(t, subscriber, "serve_ipxe_over_tftp")
 
 		expectNoEvent(t, subscriber)
 
-		want := "[{init bogustime} {jump_to bogustime} {served_ipxe_over_tftp bogustime}]"
+		want := "[{init bogustime} {jump_to bogustime} {serve_ipxe_over_tftp bogustime}]"
 		if fmt.Sprint(machine.Events.Slice()) != want {
 			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
 		}

--- a/machine_test.go
+++ b/machine_test.go
@@ -11,8 +11,19 @@ import (
 func expectEvent(t *testing.T, subscriber chan IdentifiedEvent, event string) {
 	select {
 	case v := <-subscriber:
-		if v.Event.Event != event {
+		if v.Event.Event != event || v.Event.Repeated != false {
 			t.Fatalf("Expected to get the %s event, got: %v", event, v)
+		}
+	default:
+		t.Fatalf("Expected to get the %s event, got nothing", event)
+	}
+}
+
+func expectRepeatEvent(t *testing.T, subscriber chan IdentifiedEvent, event string) {
+	select {
+	case v := <-subscriber:
+		if v.Event.Event != event || v.Event.Repeated != true {
+			t.Fatalf("Expected to get the repeated %s event, got: %v (repeated: %v)", event, v, v.Event.Repeated)
 		}
 	default:
 		t.Fatalf("Expected to get the %s event, got nothing", event)
@@ -41,9 +52,10 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -52,9 +64,10 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 
 		expectEvent(t, subscriber, "firmware_init")
 
-		want := "[{init bogustime} {firmware_init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -62,9 +75,10 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "http_boot")
 		expectEvent(t, subscriber, "http_boot")
 
-		want := "[{init bogustime} {firmware_init bogustime} {http_boot bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {http_boot bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -84,9 +98,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -94,9 +109,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "firmware_init")
 		expectEvent(t, subscriber, "firmware_init")
 
-		want := "[{init bogustime} {firmware_init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -104,9 +120,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "point_pxe_to_ipxe_over_tftp")
 		expectEvent(t, subscriber, "point_pxe_to_ipxe_over_tftp")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -114,9 +131,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "serve_ipxe_over_tftp")
 		expectEvent(t, subscriber, "serve_ipxe_over_tftp")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -124,9 +142,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "point_ipxe_to_http_boot")
 		expectEvent(t, subscriber, "point_ipxe_to_http_boot")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -134,9 +153,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "http_fetch_uki")
 		expectEvent(t, subscriber, "http_fetch_uki")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -144,19 +164,21 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 		machine.Event(context.Background(), "os_init")
 		expectEvent(t, subscriber, "os_init")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []} {os_init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
 	{
 		machine.Event(context.Background(), "os_init")
-		expectNoEvent(t, subscriber)
+		expectRepeatEvent(t, subscriber, "os_init")
 
-		want := "[{init bogustime} {firmware_init bogustime} {point_pxe_to_ipxe_over_tftp bogustime} {serve_ipxe_over_tftp bogustime} {point_ipxe_to_http_boot bogustime} {http_fetch_uki bogustime} {os_init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []} {os_init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -176,9 +198,10 @@ func TestTransitionsJumpTo(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -190,9 +213,10 @@ func TestTransitionsJumpTo(t *testing.T) {
 
 		expectNoEvent(t, subscriber)
 
-		want := "[{init bogustime} {jump_to bogustime} {serve_ipxe_over_tftp bogustime}]"
-		if fmt.Sprint(machine.Events.Slice()) != want {
-			t.Fatalf("Wanted %s, got %s", want, machine.Events.Slice())
+		want := "[{init bogustime false []} {jump_to bogustime false []} {serve_ipxe_over_tftp bogustime false []}]"
+		got := fmt.Sprint(machine.Events.Slice())
+		if got != want {
+			t.Fatalf("Wanted %s, got %s", want, got)
 		}
 	}
 
@@ -214,7 +238,7 @@ func TestEncodeMachines(t *testing.T) {
 	}
 	json := string(jsonbytes)
 
-	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\"},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\"}]}}"
+	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"arguments\":null},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"arguments\":null}]}}"
 	if json != want {
 		t.Fatalf("Wanted %s,\ngot: %s", want, json)
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -52,7 +52,7 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime false []}]"
+		want := "[{init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -60,11 +60,11 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "firmware_init")
+		machine.Event(context.Background(), "firmware_init", nil)
 
 		expectEvent(t, subscriber, "firmware_init")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -72,10 +72,10 @@ func TestTransitionsHttpBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "http_boot")
+		machine.Event(context.Background(), "http_boot", nil)
 		expectEvent(t, subscriber, "http_boot")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {http_boot bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {http_boot bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -98,7 +98,7 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime false []}]"
+		want := "[{init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -106,10 +106,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "firmware_init")
+		machine.Event(context.Background(), "firmware_init", nil)
 		expectEvent(t, subscriber, "firmware_init")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -117,10 +117,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "point_pxe_to_ipxe_over_tftp")
+		machine.Event(context.Background(), "point_pxe_to_ipxe_over_tftp", nil)
 		expectEvent(t, subscriber, "point_pxe_to_ipxe_over_tftp")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -128,10 +128,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "serve_ipxe_over_tftp")
+		machine.Event(context.Background(), "serve_ipxe_over_tftp", nil)
 		expectEvent(t, subscriber, "serve_ipxe_over_tftp")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -139,10 +139,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "point_ipxe_to_http_boot")
+		machine.Event(context.Background(), "point_ipxe_to_http_boot", nil)
 		expectEvent(t, subscriber, "point_ipxe_to_http_boot")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>} {point_ipxe_to_http_boot bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -150,10 +150,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "http_fetch_uki")
+		machine.Event(context.Background(), "http_fetch_uki", nil)
 		expectEvent(t, subscriber, "http_fetch_uki")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>} {point_ipxe_to_http_boot bogustime false <nil>} {http_fetch_uki bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -161,10 +161,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "os_init")
+		machine.Event(context.Background(), "os_init", nil)
 		expectEvent(t, subscriber, "os_init")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []} {os_init bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>} {point_ipxe_to_http_boot bogustime false <nil>} {http_fetch_uki bogustime false <nil>} {os_init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -172,10 +172,10 @@ func TestTransitionsPxeBootMatchEvents(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "os_init")
+		machine.Event(context.Background(), "os_init", nil)
 		expectRepeatEvent(t, subscriber, "os_init")
 
-		want := "[{init bogustime false []} {firmware_init bogustime false []} {point_pxe_to_ipxe_over_tftp bogustime false []} {serve_ipxe_over_tftp bogustime false []} {point_ipxe_to_http_boot bogustime false []} {http_fetch_uki bogustime false []} {os_init bogustime false []}]"
+		want := "[{init bogustime false <nil>} {firmware_init bogustime false <nil>} {point_pxe_to_ipxe_over_tftp bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>} {point_ipxe_to_http_boot bogustime false <nil>} {http_fetch_uki bogustime false <nil>} {os_init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -198,7 +198,7 @@ func TestTransitionsJumpTo(t *testing.T) {
 	{
 		expectEvent(t, subscriber, "init")
 
-		want := "[{init bogustime false []}]"
+		want := "[{init bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -206,14 +206,14 @@ func TestTransitionsJumpTo(t *testing.T) {
 	}
 
 	{
-		machine.Event(context.Background(), "serve_ipxe_over_tftp")
+		machine.Event(context.Background(), "serve_ipxe_over_tftp", nil)
 		expectEvent(t, subscriber, "jump_to")
 
 		expectEvent(t, subscriber, "serve_ipxe_over_tftp")
 
 		expectNoEvent(t, subscriber)
 
-		want := "[{init bogustime false []} {jump_to bogustime false []} {serve_ipxe_over_tftp bogustime false []}]"
+		want := "[{init bogustime false <nil>} {jump_to bogustime false <nil>} {serve_ipxe_over_tftp bogustime false <nil>}]"
 		got := fmt.Sprint(machine.Events.Slice())
 		if got != want {
 			t.Fatalf("Wanted %s, got %s", want, got)
@@ -230,7 +230,7 @@ func TestEncodeMachines(t *testing.T) {
 	broker := NewBroker()
 	machines := NewMachines(broker)
 
-	machines.GetOrInitMachine(mac).Event(context.Background(), "http_boot")
+	machines.GetOrInitMachine(mac).Event(context.Background(), "http_boot", nil)
 
 	jsonbytes, err := json.Marshal(machines)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestEncodeMachines(t *testing.T) {
 	}
 	json := string(jsonbytes)
 
-	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"arguments\":null},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"arguments\":null}]}}"
+	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null}]}}"
 	if json != want {
 		t.Fatalf("Wanted %s,\ngot: %s", want, json)
 	}

--- a/machine_test.go
+++ b/machine_test.go
@@ -238,7 +238,7 @@ func TestEncodeMachines(t *testing.T) {
 	}
 	json := string(jsonbytes)
 
-	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null}]}}"
+	want := "{\"04:42:1a:03:9b:20\":{\"Mac\":\"04:42:1a:03:9b:20\",\"IPv6Address\":\"\",\"Events\":[{\"event\":\"init\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null},{\"event\":\"http_boot\",\"timestamp\":\"bogustime\",\"repeat_event\":false,\"detail\":null}]}}"
 	if json != want {
 		t.Fatalf("Wanted %s,\ngot: %s", want, json)
 	}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"slices"
 	"strings"
@@ -516,12 +517,22 @@ func main() {
 		log.Fatalf("Failed to initialize webserver: %v", err)
 	}
 
+	baseLogger := log.New(os.Stderr, "", log.LstdFlags)
+
+	logHook := &FyiHookWriter{
+		w: baseLogger.Writer(),
+		copyTo: func(msg string) {
+			broker.PublishFyi(msg)
+		},
+	}
+
 	// run HTTP
 	go func() {
 		log.Printf("HTTP server listening on %s", *httpListenAddr)
 		server := &http.Server{
-			Addr:    *httpListenAddr,
-			Handler: mux,
+			Addr:     *httpListenAddr,
+			Handler:  mux,
+			ErrorLog: log.New(logHook, "", log.LstdFlags),
 		}
 
 		err = server.ListenAndServe()
@@ -543,10 +554,12 @@ func main() {
 			if err != nil {
 				log.Fatalf("Server failed: %v", err)
 			}
+
 			server := &http.Server{
 				Addr:      *httpsListenAddr,
 				Handler:   mux,
 				TLSConfig: tlsConfig,
+				ErrorLog:  log.New(logHook, "", log.LstdFlags),
 			}
 
 			err = server.ListenAndServeTLS("", "")

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -458,29 +457,6 @@ func parseMACFromPath(s string) (net.HardwareAddr, error) {
 	}
 
 	return mac, nil
-}
-
-func tftpReadHandler(filename string, rf io.ReaderFrom) error {
-	mac, err := parseMACFromPath(filename)
-	if err != nil {
-		log.Println("Can't parse a MAC from ", filename, err)
-		return err
-	}
-
-	log.Println("Serving ", filename)
-
-	machine := machines.GetOrInitMachine(mac)
-	machine.Event(context.Background(), "serve_ipxe_over_tftp")
-
-	r := bytes.NewReader(ipxe_efi_x86_64)
-	n, err := rf.ReadFrom(r)
-	if err != nil {
-		log.Printf("Serving failure: %v", err)
-		return err
-	}
-	log.Printf("%d bytes sent for %s", n, filename)
-	return nil
-
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -470,7 +470,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	log.Println("Serving ", filename)
 
 	machine := machines.GetOrInitMachine(mac)
-	machine.Event(context.Background(), "served_ipxe_over_tftp")
+	machine.Event(context.Background(), "serve_ipxe_over_tftp")
 
 	r := bytes.NewReader(ipxe_efi_x86_64)
 	n, err := rf.ReadFrom(r)

--- a/main.go
+++ b/main.go
@@ -382,7 +382,7 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 
 	if httpBootTemplate != nil {
 		if wantsHttpBootFile(msg) {
-			machine.Event(context.Background(), "http_boot")
+			machine.Event(context.Background(), "http_boot", nil)
 			payload, err := archsToEncoded(msg.Options.ArchTypes())
 			if err != nil {
 				log.Printf("failed to construct the arch payload: %s", err)
@@ -405,10 +405,10 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 				resp.AddOption(dhcpv6.OptBootFileURL(buf.String()))
 			}
 		} else if wantsiPxeOverTftp(msg) {
-			machine.Event(context.Background(), "point_pxe_to_ipxe_over_tftp")
+			machine.Event(context.Background(), "point_pxe_to_ipxe_over_tftp", nil)
 			resp.AddOption(dhcpv6.OptBootFileURL(fmt.Sprintf("tftp://[%s]/%s/ipxe.efi", *baseAddress, mac.String())))
 		} else if wantsiPxeChainToHttp(msg) {
-			machine.Event(context.Background(), "point_ipxe_to_http_boot")
+			machine.Event(context.Background(), "point_ipxe_to_http_boot", nil)
 			payload, err := archsToEncoded(msg.Options.ArchTypes())
 			if err != nil {
 				log.Printf("failed to construct the arch payload: %s", err)
@@ -431,9 +431,9 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 				// Firmware seems to make a follow-up solicit/request for just DNS, which should not move us to os_init
 				log.Printf("Detected firmware DNS follow-up request, skipping state transition")
 			} else if msg.Options.ArchTypes() == nil {
-				machine.Event(context.Background(), "os_init")
+				machine.Event(context.Background(), "os_init", nil)
 			} else {
-				machine.Event(context.Background(), "firmware_init")
+				machine.Event(context.Background(), "firmware_init", nil)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"runtime"
 	"slices"
 	"strings"
 	"text/template"
@@ -38,6 +39,10 @@ type DHCPv6Handler struct {
 var (
 	baseAddress         = flag.String("base-address", "fec0::", "IPv6 base address to distribute MAC-based IPs through, we assume its a /72")
 	networkInterface    = flag.String("interface", "eth0", "Interface to listen on")
+	tftpListenAddr      = flag.String("tftp-listen-addr", ":69", "Address/port to listen for TFTP on. Note: if not all addresses, you must listen on a `base-address`-member address.")
+	httpListenAddr      = flag.String("http-listen-addr", ":80", "Address/port to listen for HTTP on. Note: if not all addresses, you must listen on a `base-address`-member address.")
+	httpsListenAddr     = flag.String("https-listen-addr", ":443", "Address/port to listen for HTTPS on. Note: if not all addresses, you must listen on a `base-address`-member address.")
+	dhcpv6ListenPort    = flag.Int("dhcpv6-listen-port", dhcpv6.DefaultServerPort, "Port to listen for DHCPv6 requests (only useful for testing.)")
 	httpBootURLTemplate = flag.String("http-boot-url-template", "", "URL template for HTTP boot requests, like http://netboot.target/?mac={{.MAC}}")
 	tlsCertFile         = flag.String("tls-cert-file", "", "Path to TLS Certificate File")
 	tlsKeyFile          = flag.String("tls-key-file", "", "Path to TLS Key File")
@@ -516,33 +521,20 @@ func main() {
 		},
 	}
 
-	listenAddr := &net.UDPAddr{
-		IP:   dhcpv6.AllDHCPRelayAgentsAndServers,
-		Port: dhcpv6.DefaultServerPort,
-		Zone: *baseAddress,
-	}
-
-	laddr := &net.UDPAddr{
-		IP:   net.IPv6unspecified,
-		Port: dhcpv6.DefaultServerPort,
-	}
-
 	broker := NewBroker()
 	machines = NewMachines(broker)
 
 	go func() {
-		log.Printf("Starting the TFTP server on port 69")
+		log.Printf("Starting the TFTP server on %s", *tftpListenAddr)
 		tftpServer := tftp.NewServer(tftpReadHandler, nil)
 		tftpServer.SetTimeout(5 * time.Second) // optional
 
-		e := tftpServer.ListenAndServe(":69") // blocks until s.Shutdown() is called
+		e := tftpServer.ListenAndServe(*tftpListenAddr) // blocks until s.Shutdown() is called
 		if e != nil {
 			log.Fatalf("starting TFTP server: %v", e)
 		}
 	}()
 
-	httpAddr := ":80"
-	httpsAddr := ":443"
 	mux, err := webserver(*netbootDir, broker, machines)
 	if err != nil {
 		log.Fatalf("Failed to initialize webserver: %v", err)
@@ -550,9 +542,9 @@ func main() {
 
 	// run HTTP
 	go func() {
-		log.Printf("HTTP server listening on %s", httpAddr)
+		log.Printf("HTTP server listening on %s", *httpListenAddr)
 		server := &http.Server{
-			Addr:    httpAddr,
+			Addr:    *httpListenAddr,
 			Handler: mux,
 		}
 
@@ -565,7 +557,7 @@ func main() {
 	// run HTTPS
 	if useTls {
 		go func() {
-			log.Printf("HTTPs server listening on %s", httpsAddr)
+			log.Printf("HTTPs server listening on %s", *httpsListenAddr)
 			cwTlsConfig := certwatcher.TLSConfig{
 				CertPath:   *tlsCertFile,
 				KeyPath:    *tlsKeyFile,
@@ -576,7 +568,7 @@ func main() {
 				log.Fatalf("Server failed: %v", err)
 			}
 			server := &http.Server{
-				Addr:      httpsAddr,
+				Addr:      *httpsListenAddr,
 				Handler:   mux,
 				TLSConfig: tlsConfig,
 			}
@@ -588,12 +580,26 @@ func main() {
 		}()
 	}
 
-	server, err := server6.NewServer(*networkInterface, laddr, dhcpv6Handler.Handler)
+	laddr := &net.UDPAddr{
+		IP:   net.IPv6unspecified,
+		Port: *dhcpv6ListenPort,
+	}
+
+	var server *server6.Server
+	if runtime.GOOS == "darwin" {
+		// macOS: avoid BindToInterface, which is currently broken for IPv6 sockets
+		log.Printf("attempting to listen via UDP on %s on all interfaces to work around BindToInterface on macOS", laddr)
+		server, err = server6.NewServer("", laddr, dhcpv6Handler.Handler)
+	} else {
+		log.Printf("attempting to listen via UDP on %s (iface %s)", laddr, *networkInterface)
+		server, err = server6.NewServer(*networkInterface, laddr, dhcpv6Handler.Handler)
+	}
+
 	if err != nil {
 		log.Fatalf("starting DHCPv6 server: %s", err)
 	}
 
-	log.Printf("listening via UDP on %s", listenAddr)
+	log.Printf("DHCPv6 listening via UDP on %s", laddr)
 	if err = server.Serve(); err != nil {
 		log.Fatalf("DHCPv6 server exited: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -338,6 +338,7 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 	copy(prefix, s.baseAddress[:10])
 	leasedIP = append(prefix, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
 
+	machine.IPv6Address = leasedIP
 	log.Printf("Assigning %v to %v", leasedIP, mac)
 
 	err = s.checkIA(msg, leasedIP)

--- a/main.go
+++ b/main.go
@@ -338,7 +338,7 @@ func (s *DHCPv6Handler) process(peer net.Addr, msg *dhcpv6.Message,
 	copy(prefix, s.baseAddress[:10])
 	leasedIP = append(prefix, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
 
-	machine.IPv6Address = leasedIP
+	machine.SetIPv6Address(leasedIP)
 	log.Printf("Assigning %v to %v", leasedIP, mac)
 
 	err = s.checkIA(msg, leasedIP)

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -11,7 +11,7 @@ type TransferEvent struct {
 	Error      string `json:"error,omitempty"`
 }
 
-const five_mib = 5 * 1024 * 1024
+const fiveMiB = 5 * 1024 * 1024
 
 type progressReader struct {
 	r          io.Reader
@@ -24,7 +24,7 @@ type progressReader struct {
 func newProgressReader(r io.Reader, onMark func(bytes int64) error) *progressReader {
 	return &progressReader{
 		r:        r,
-		nextMark: five_mib,
+		nextMark: fiveMiB,
 		onMark:   onMark,
 	}
 }
@@ -38,7 +38,7 @@ func (p *progressReader) Read(b []byte) (int, error) {
 			if err := p.onMark(p.total); err != nil {
 				return n, err
 			}
-			p.nextMark += five_mib
+			p.nextMark += fiveMiB
 		}
 	}
 

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -35,7 +35,7 @@ func (p *progressReader) Read(b []byte) (int, error) {
 		p.total += int64(n)
 
 		for p.total >= p.nextMark {
-			if err := p.onMark(p.nextMark); err != nil {
+			if err := p.onMark(p.total); err != nil {
 				return n, err
 			}
 			p.nextMark += five_mib

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -1,0 +1,45 @@
+package main
+
+import "io"
+
+const five_mib = 5 * 1024 * 1024
+
+type progressReader struct {
+	r          io.Reader
+	total      int64
+	nextMark   int64
+	firedFinal bool
+	onMark     func(bytes int64) error
+}
+
+func newProgressReader(r io.Reader, onMark func(bytes int64) error) *progressReader {
+	return &progressReader{
+		r:        r,
+		nextMark: five_mib,
+		onMark:   onMark,
+	}
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.total += int64(n)
+
+		for p.total >= p.nextMark {
+			if err := p.onMark(p.nextMark); err != nil {
+				return n, err
+			}
+			p.nextMark += five_mib
+		}
+	}
+
+	// If we've hit EOF, emit one final progress event
+	if err == io.EOF && !p.firedFinal {
+		p.firedFinal = true
+		if err := p.onMark(p.total); err != nil {
+			return n, err
+		}
+	}
+
+	return n, err
+}

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -2,6 +2,14 @@ package main
 
 import "io"
 
+type TransferEvent struct {
+	Filename   string `json:"file_name"`
+	State      string `json:"state"`
+	SentBytes  int64  `json:"sent_bytes"`
+	TotalBytes int64  `json:"total_bytes"`
+	Error      error  `json:"error"`
+}
+
 const five_mib = 5 * 1024 * 1024
 
 type progressReader struct {

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -8,7 +8,7 @@ type TransferEvent struct {
 	State      string `json:"state"`
 	SentBytes  int64  `json:"sent_bytes"`
 	TotalBytes int64  `json:"total_bytes"`
-	Error      error  `json:"error"`
+	Error      string `json:"error,omitempty"`
 }
 
 const five_mib = 5 * 1024 * 1024

--- a/progress_reader.go
+++ b/progress_reader.go
@@ -3,6 +3,7 @@ package main
 import "io"
 
 type TransferEvent struct {
+	Protocol   string `json:"protocol"`
 	Filename   string `json:"file_name"`
 	State      string `json:"state"`
 	SentBytes  int64  `json:"sent_bytes"`
@@ -44,6 +45,7 @@ func (p *progressReader) Read(b []byte) (int, error) {
 	// If we've hit EOF, emit one final progress event
 	if err == io.EOF && !p.firedFinal {
 		p.firedFinal = true
+
 		if err := p.onMark(p.total); err != nil {
 			return n, err
 		}

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -39,7 +39,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	n, err := rf.ReadFrom(r)
 	if err != nil {
 		tftpevent.State = "error"
-		tftpevent.Error = err
+		tftpevent.Error = err.Error()
 		machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
 		log.Printf("Serving failure: %v", err)
 		return err

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -19,6 +19,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	underlying_reader := bytes.NewReader(ipxe_efi_x86_64)
 
 	tftpevent := TransferEvent{
+		Protocol:   "tftp",
 		Filename:   filename,
 		State:      "init",
 		TotalBytes: underlying_reader.Size(),

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -7,14 +7,6 @@ import (
 	"log"
 )
 
-type ServeIPXEOverTFTPEvent struct {
-	Filename   string `json:"file_name"`
-	State      string `json:"state"`
-	SentBytes  int64  `json:"sent_bytes"`
-	TotalBytes int64  `json:"total_bytes"`
-	Error      error  `json:"error"`
-}
-
 func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	mac, err := parseMACFromPath(filename)
 	if err != nil {
@@ -26,7 +18,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 
 	underlying_reader := bytes.NewReader(ipxe_efi_x86_64)
 
-	tftpevent := ServeIPXEOverTFTPEvent{
+	tftpevent := TransferEvent{
 		Filename:   filename,
 		State:      "init",
 		TotalBytes: underlying_reader.Size(),

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -38,6 +38,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	})
 	n, err := rf.ReadFrom(r)
 	if err != nil {
+		tftpevent.State = "error"
 		tftpevent.Error = err
 		machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
 		log.Printf("Serving failure: %v", err)

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+)
+
+type ServeIPXEOverTFTPEvent struct {
+	Filename   string `json:"file_name"`
+	State      string `json:"state"`
+	SentBytes  int64  `json:"sent_bytes"`
+	TotalBytes int64  `json:"total_bytes"`
+	Error      error  `json:"error"`
+}
+
+func tftpReadHandler(filename string, rf io.ReaderFrom) error {
+	mac, err := parseMACFromPath(filename)
+	if err != nil {
+		log.Println("Can't parse a MAC from ", filename, err)
+		return err
+	}
+
+	log.Println("Serving ", filename)
+
+	underlying_reader := bytes.NewReader(ipxe_efi_x86_64)
+
+	tftpevent := ServeIPXEOverTFTPEvent{
+		Filename:   filename,
+		State:      "init",
+		TotalBytes: underlying_reader.Size(),
+		SentBytes:  0,
+	}
+
+	machine := machines.GetOrInitMachine(mac)
+	machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
+
+	tftpevent.State = "sending"
+
+	r := newProgressReader(underlying_reader, func(bytes int64) error {
+		tftpevent.SentBytes = bytes
+		machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
+		return nil
+	})
+	n, err := rf.ReadFrom(r)
+	if err != nil {
+		tftpevent.Error = err
+		machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
+		log.Printf("Serving failure: %v", err)
+		return err
+	}
+
+	tftpevent.State = "complete"
+	machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
+	log.Printf("%d bytes sent for %s", n, filename)
+	return nil
+
+}


### PR DESCRIPTION

<img width="1828" height="712" alt="CleanShot 2025-11-27 at 00 16 03@2x" src="https://github.com/user-attachments/assets/d6ecf899-c788-4f53-9fd7-1a34939de24a" />

* Includes the IPv6 address of the device
* No longer squashes duplicate events as a "repeat"
* Includes additional detail, like transfer progress and the protocol being used
* Introduces new "fyi" events which are log events that aren't strictly/easily tied to a specific device and are sent to all consumers. In particular TLS client trust issues:

<img width="2568" height="390" alt="CleanShot 2025-11-27 at 00 17 40@2x" src="https://github.com/user-attachments/assets/cbe3adc2-ef31-4c2b-bce4-97e106bed84b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPv6 address support for machines
  * File-transfer progress reporting with incremental events
  * Configurable TFTP/HTTP/HTTPS/DHCPv6 listeners
  * Enhanced event payloads with repeat/detail and FYI publish/log hooks

* **Bug Fixes**
  * Fixed event name typos in documentation/examples

* **Chores**
  * Ignored new build artifacts (.scratch, ipxe.efi) and CI touch step
  * Added build/setup targets and packaging tweaks

* **Tests**
  * Updated tests to expect expanded event format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->