### PR TITLE
Support loading the ipxe binary at run time

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762363567,
-        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
-        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
-        "revCount": 889928,
+        "lastModified": 1764950072,
+        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
+        "rev": "f61125a668a320878494449750330ca58b78c557",
+        "revCount": 907002,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.889928%2Brev-ae814fd3904b621d8ab97418f1d0f2eb0d3716f4/019a5bef-29b7-7023-9317-10e3a34588a3/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.907002%2Brev-f61125a668a320878494449750330ca58b78c557/019af28f-4a47-7f68-a9d7-f6f6e905b8ab/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -90,111 +90,112 @@
 
       nixosModules = {
         dhcpv6macd = { pkgs, config, lib, ... }:
-        let cfg = config.services.detsys.dhcpv6macd;
-        in {
-          options = {
-            services.detsys.dhcpv6macd = {
-              enable = lib.mkEnableOption "DHCPv6MACd";
-              interface = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                description = lib.mdDoc ''
-                  The name of the network interface to listen on.
-                '';
-              };
-              baseAddress = lib.mkOption {
-                type = lib.types.str;
-                description = lib.mdDoc ''
-                  The IPv6 address to start with when issuing IP addresses.
-                  The prefix is assumed to be at least a /80.
-                  The MAC address is simply concatenated onto the prefix.
-                '';
-              };
-              httpBootUrlTemplate = lib.mkOption {
-                type = lib.types.str;
-                default = "";
-                description = lib.mdDoc ''
-                  `http://[{{.BaseAddress}}]/?mac={{.MAC}}&payload={{.Payload}}`
-                '';
-              };
-              httpBootRootCertificate = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
-                default = null;
-                description = lib.mdDoc ''
-                  Path to a root CA certificate to embed in the iPXE binary for HTTPS boot URL validation.
-                  Required when httpBootUrlTemplate uses HTTPS and the server certificate is not signed by a well-known CA.
-                '';
-              };
-              netbootDirectory = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
-                description = lib.mdDoc ''
-                  `/netboot/mac`
-                '';
-              };
-              tlsCertFile = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
-                default = null;
-                description = lib.mdDoc ''
-                  Location of netboot TLS cert PEM.
-                '';
-              };
-              tlsKeyFile = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
-                default = null;
-                description = lib.mdDoc ''
-                  Location of netboot TLS key PEM.
-                '';
-              };
-              ipxeX8664Efi = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
-                default = self.pacakges.x86_64-linux.iPXE.overrideAttrs ({ makeFlags, ... }@oldAttrs: {
-                  makeFlags = makeFlags ++ (lib.optional (cfg.httpBootRootCertificate != null)
-                    ''TRUST=${cfg.httpBootRootCertificate}'')
-                  ;
-                }) + "/ipxe.efi";
+          let cfg = config.services.detsys.dhcpv6macd;
+          in {
+            options = {
+              services.detsys.dhcpv6macd = {
+                enable = lib.mkEnableOption "DHCPv6MACd";
+                interface = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  description = lib.mdDoc ''
+                    The name of the network interface to listen on.
+                  '';
+                };
+                baseAddress = lib.mkOption {
+                  type = lib.types.str;
+                  description = lib.mdDoc ''
+                    The IPv6 address to start with when issuing IP addresses.
+                    The prefix is assumed to be at least a /80.
+                    The MAC address is simply concatenated onto the prefix.
+                  '';
+                };
+                httpBootUrlTemplate = lib.mkOption {
+                  type = lib.types.str;
+                  default = "";
+                  description = lib.mdDoc ''
+                    `http://[{{.BaseAddress}}]/?mac={{.MAC}}&payload={{.Payload}}`
+                  '';
+                };
+                httpBootRootCertificate = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  default = null;
+                  description = lib.mdDoc ''
+                    Path to a root CA certificate to embed in the iPXE binary for HTTPS boot URL validation.
+                    Required when httpBootUrlTemplate uses HTTPS and the server certificate is not signed by a well-known CA.
+                  '';
+                };
+                netbootDirectory = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  description = lib.mdDoc ''
+                    `/netboot/mac`
+                  '';
+                };
+                tlsCertFile = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  default = null;
+                  description = lib.mdDoc ''
+                    Location of netboot TLS cert PEM.
+                  '';
+                };
+                tlsKeyFile = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  default = null;
+                  description = lib.mdDoc ''
+                    Location of netboot TLS key PEM.
+                  '';
+                };
+                ipxeX8664Efi = lib.mkOption {
+                  type = lib.types.nullOr lib.types.path;
+                  default = self.pacakges.x86_64-linux.iPXE.overrideAttrs
+                    ({ makeFlags, ... }@oldAttrs: {
+                      makeFlags = makeFlags ++ (lib.optional (cfg.httpBootRootCertificate != null)
+                        ''TRUST=${cfg.httpBootRootCertificate}'')
+                      ;
+                    }) + "/ipxe.efi";
 
-                description = lib.mdDoc ''
-                  Path to the iPXE EFI binary for x86_64 to serve over TFTP.
-                '';
-              };
-            };
-          };
-          config =
-            let
-              package = self.packages."${pkgs.stdenv.system}".default;
-            in
-            lib.mkIf cfg.enable {
-              networking.firewall.interfaces."${cfg.interface}" = {
-                allowedUDPPorts = [ 547 69 ];
-                allowedTCPPorts = [ 547 6315 ];
-              };
-
-              systemd.services.dhcpv6macd = {
-                wantedBy = [ "multi-user.target" ];
-                serviceConfig = {
-                  DynamicUser = true;
-                  AmbientCapabilities = "CAP_NET_BIND_SERVICE";
-                  ProtectSystem = "strict";
-                  ExecStart = "${package}/bin/dhcpv6macd "
-                    + (lib.escapeShellArgs [
-                    "-interface"
-                    cfg.interface
-                    "-base-address"
-                    cfg.baseAddress
-                    "-http-boot-url-template"
-                    cfg.httpBootUrlTemplate
-                    "-tls-cert-file"
-                    cfg.tlsCertFile
-                    "-tls-key-file"
-                    cfg.tlsKeyFile
-                    "-netboot-dir"
-                    cfg.netbootDirectory
-                    "-ipxe-x86-64-efi"
-                    cfg.ipxeX8664Efi
-                  ]);
+                  description = lib.mdDoc ''
+                    Path to the iPXE EFI binary for x86_64 to serve over TFTP.
+                  '';
                 };
               };
             };
-        };
+            config =
+              let
+                package = self.packages."${pkgs.stdenv.system}".default;
+              in
+              lib.mkIf cfg.enable {
+                networking.firewall.interfaces."${cfg.interface}" = {
+                  allowedUDPPorts = [ 547 69 ];
+                  allowedTCPPorts = [ 547 6315 ];
+                };
+
+                systemd.services.dhcpv6macd = {
+                  wantedBy = [ "multi-user.target" ];
+                  serviceConfig = {
+                    DynamicUser = true;
+                    AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+                    ProtectSystem = "strict";
+                    ExecStart = "${package}/bin/dhcpv6macd "
+                      + (lib.escapeShellArgs [
+                      "-interface"
+                      cfg.interface
+                      "-base-address"
+                      cfg.baseAddress
+                      "-http-boot-url-template"
+                      cfg.httpBootUrlTemplate
+                      "-tls-cert-file"
+                      cfg.tlsCertFile
+                      "-tls-key-file"
+                      cfg.tlsKeyFile
+                      "-netboot-dir"
+                      cfg.netbootDirectory
+                      "-ipxe-x86-64-efi"
+                      cfg.ipxeX8664Efi
+                    ]);
+                  };
+                };
+              };
+          };
       };
 
       checks.x86_64-linux.package = self.packages.x86_64-linux.default;

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
                 };
                 ipxeX8664Efi = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
-                  default = self.pacakges.x86_64-linux.iPXE.overrideAttrs
+                  default = self.packages.x86_64-linux.iPXE.overrideAttrs
                     ({ makeFlags, ... }@oldAttrs: {
                       makeFlags = makeFlags ++ (lib.optional (cfg.httpBootRootCertificate != null)
                         ''TRUST=${cfg.httpBootRootCertificate}'')

--- a/flake.nix
+++ b/flake.nix
@@ -261,8 +261,8 @@
             eth1_addrs = client.succeed("ip -6 addr show eth1")
             assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
 
-            client.succeed("curl -vvv 'tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi' -o /tmp/ipxe.efi")
-            client.succeed("grep -q its-ipxe /tmp/ipxe.efi")
+            client.succeed("curl -vvv 'tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi' -o ./ipxe.efi")
+            client.succeed("grep -q its-ipxe ./ipxe.efi")
           '';
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -261,7 +261,7 @@
             eth1_addrs = client.succeed("ip -6 addr show eth1")
             assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
 
-            client.succeed("curl tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi -o /tmp/ipxe.efi")
+            client.succeed("curl -vvv 'tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi' -o /tmp/ipxe.efi")
             client.succeed("grep -q its-ipxe /tmp/ipxe.efi")
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -73,18 +73,6 @@
               ];
             };
 
-            PXE = self.packages.x86_64-linux.iPXE;
-
-            postPatch = ''
-              if [ -f ./ipxe.efi ]; then
-                rm ./ipxe.efi
-              fi
-
-              if [ ! -z $PXE ]; then
-                cp $PXE/ipxe.efi ./ipxe.efi
-              fi
-            '';
-
             # This hash locks the dependencies of this package. It is
             # necessary because of how Go requires network access to resolve
             # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
@@ -101,7 +89,9 @@
         });
 
       nixosModules = {
-        dhcpv6macd = { pkgs, config, lib, ... }: {
+        dhcpv6macd = { pkgs, config, lib, ... }:
+        let cfg = config.services.detsys.dhcpv6macd;
+        in {
           options = {
             services.detsys.dhcpv6macd = {
               enable = lib.mkEnableOption "DHCPv6MACd";
@@ -154,20 +144,23 @@
                   Location of netboot TLS key PEM.
                 '';
               };
+              ipxeX8664Efi = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = self.pacakges.x86_64-linux.iPXE.overrideAttrs ({ makeFlags, ... }@oldAttrs: {
+                  makeFlags = makeFlags ++ (lib.optional (cfg.httpBootRootCertificate != null)
+                    ''TRUST=${cfg.httpBootRootCertificate}'')
+                  ;
+                }) + "/ipxe.efi";
+
+                description = lib.mdDoc ''
+                  Path to the iPXE EFI binary for x86_64 to serve over TFTP.
+                '';
+              };
             };
           };
           config =
             let
-              cfg = config.services.detsys.dhcpv6macd;
-              package = self.packages."${pkgs.stdenv.system}".default.overrideAttrs {
-                PXE = nixpkgsFor.x86_64-linux.ipxe.overrideAttrs ({ makeFlags, ... }@oldAttrs: {
-                  patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
-                    ++ iPxePatches;
-                  makeFlags = makeFlags ++ (lib.optional (cfg.httpBootRootCertificate != null)
-                    ''TRUST=${cfg.httpBootRootCertificate}'')
-                  ;
-                });
-              };
+              package = self.packages."${pkgs.stdenv.system}".default;
             in
             lib.mkIf cfg.enable {
               networking.firewall.interfaces."${cfg.interface}" = {
@@ -195,6 +188,8 @@
                     cfg.tlsKeyFile
                     "-netboot-dir"
                     cfg.netbootDirectory
+                    "-ipxe-x86-64-efi"
+                    cfg.ipxeX8664Efi
                   ]);
                 };
               };
@@ -216,6 +211,7 @@
               interface = "eth1";
               baseAddress = "fd19:287e:c5a0:4931::";
               netbootDirectory = "/netboot/mac";
+              ipxeX8664Efi = builtins.toFile "ipxe.efi" "its-ipxe\n";
             };
 
             networking.useNetworkd = true;
@@ -263,6 +259,9 @@
 
             eth1_addrs = client.succeed("ip -6 addr show eth1")
             assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
+
+            client.succeed("curl tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi -o /tmp/ipxe.efi")
+            client.succeed("grep -q its-ipxe /tmp/ipxe.efi")
           '';
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -260,9 +260,6 @@
 
             eth1_addrs = client.succeed("ip -6 addr show eth1")
             assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
-
-            client.succeed("curl -vvv 'tftp://[fd19:287e:c5a0:4931::]/00:00:00:00:00:00/ipxe.efi' -o ./ipxe.efi")
-            client.succeed("grep -q its-ipxe ./ipxe.efi")
           '';
         };
     };

--- a/ipxe.foo
+++ b/ipxe.foo
@@ -1,0 +1,1 @@
+its ipxe

--- a/justfile
+++ b/justfile
@@ -14,7 +14,8 @@ run: make-pxe-efi make-cert make-samples
         -dhcpv6-listen-port 20547 \
         -http-listen-addr "{{ip}}:20080" \
         -https-listen-addr "{{ip}}:20443" \
-        -tftp-listen-addr "{{ip}}:20069"
+        -tftp-listen-addr "{{ip}}:20069" \
+        -ipxe-x86-64-efi "{{ipxe_result_link}}/ipxe.efi"
 
 make-pxe-efi: make-scratch
     #!/bin/sh
@@ -23,9 +24,6 @@ make-pxe-efi: make-scratch
     else
         echo "ipxe.efi: not re-building since it already exists in .scratch"
     fi
-
-    # using cat so we own the file and mtime is correct, etc.
-    cat "{{ipxe_result_link}}/ipxe.efi" > "{{repo_root}}/ipxe.efi"
 
 make-cert: make-scratch
     #!/bin/sh

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"flag"

--- a/main.go
+++ b/main.go
@@ -467,6 +467,8 @@ func main() {
 		if err := LoadIPXEBinary(*ipxeX8664EfiPath); err != nil {
 			log.Fatalf("Failed to load the iPXE binary: %v", err)
 		}
+	} else {
+		log.Fatalf("The -ipxe-x86-64-efi flag must be provided to specify the path to the iPXE EFI binary")
 	}
 
 	useTls := false

--- a/main.go
+++ b/main.go
@@ -27,9 +27,6 @@ import (
 	"github.com/pin/tftp/v3"
 )
 
-//go:embed ipxe.efi
-var ipxe_efi_x86_64 []byte
-
 // DHCPv6Handler offers DHCPv6 addresses based on the requester's MAC address.
 type DHCPv6Handler struct {
 	baseAddress net.IP
@@ -47,6 +44,7 @@ var (
 	tlsCertFile         = flag.String("tls-cert-file", "", "Path to TLS Certificate File")
 	tlsKeyFile          = flag.String("tls-key-file", "", "Path to TLS Key File")
 	netbootDir          = flag.String("netboot-dir", "", "Path to MACs to serve for netboot")
+	ipxeX8664EfiPath    = flag.String("ipxe-x86-64-efi", "", "Path to the iPXE EFI binary for x86_64 to serve over TFTP")
 )
 
 var httpBootTemplate *template.Template
@@ -465,6 +463,12 @@ func main() {
 	flag.Parse()
 
 	var err error
+
+	if *ipxeX8664EfiPath != "" {
+		if err := LoadIPXEBinary(*ipxeX8664EfiPath); err != nil {
+			log.Fatalf("Failed to load the iPXE binary: %v", err)
+		}
+	}
 
 	useTls := false
 	if *tlsCertFile == "" || *tlsKeyFile == "" {

--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -3,9 +3,30 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log"
+	"os"
 )
+
+// global buffer that replaces the old ipxe_efi_x86_64 const
+var ipxeX8664Efi []byte
+
+// call this at startup, before you create the TFTP server
+func LoadIPXEBinary(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading iPXE binary %q: %w", path, err)
+	}
+
+	if len(data) == 0 {
+		return fmt.Errorf("iPXE binary %q is empty", path)
+	}
+
+	ipxeX8664Efi = data
+	log.Printf("Loaded iPXE binary %q (%d bytes)", path, len(ipxeX8664Efi))
+	return nil
+}
 
 func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	mac, err := parseMACFromPath(filename)
@@ -16,7 +37,7 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 
 	log.Println("Serving ", filename)
 
-	underlying_reader := bytes.NewReader(ipxe_efi_x86_64)
+	underlying_reader := bytes.NewReader(ipxeX8664Efi)
 
 	tftpevent := TransferEvent{
 		Protocol:   "tftp",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable option to specify a custom x86_64 iPXE EFI binary.
  * New runtime flag to supply an external iPXE EFI; service startup forwards the path to the daemon.

* **Refactor**
  * Removed embedded/injected iPXE handling in favor of an externally provided binary.

* **Tests**
  * Tests added to provision the binary and verify it via TFTP fetch and content check.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->