### PR TITLE
Set the size of the tftp file before sending

### DIFF
--- a/tftp_serve.go
+++ b/tftp_serve.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+
+	"github.com/pin/tftp/v3"
 )
 
 // global buffer that replaces the old ipxe_efi_x86_64 const
@@ -51,6 +53,8 @@ func tftpReadHandler(filename string, rf io.ReaderFrom) error {
 	machine.Event(context.Background(), "serve_ipxe_over_tftp", tftpevent)
 
 	tftpevent.State = "sending"
+
+	rf.(tftp.OutgoingTransfer).SetSize(underlying_reader.Size())
 
 	r := newProgressReader(underlying_reader, func(bytes int64) error {
 		tftpevent.SentBytes = bytes


### PR DESCRIPTION
Some PXE implementations demand it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TFTP file transfer handling by ensuring file size is properly communicated during transfers. This addresses potential issues with file transmission reliability and client compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->