### PR TITLE
Pre-can iPXE with a script that tries and tries to netboot forever

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764950072,
-        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
-        "rev": "f61125a668a320878494449750330ca58b78c557",
-        "revCount": 907002,
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "revCount": 931542,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.907002%2Brev-f61125a668a320878494449750330ca58b78c557/019af28f-4a47-7f68-a9d7-f6f6e905b8ab/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.931542%2Brev-88d3861acdd3d2f0e361767018218e51810df8a1/019be60b-f6ea-74ec-ab74-e960f412a787/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,9 @@
 
       lib = {
         mkiPXE = { system, certBundle ? null }:
-          nixpkgsFor.${system}.ipxe.overrideAttrs (oldAttrs: {
+          (nixpkgsFor.${system}.ipxe.override {
+            embedScript = ./ipxe/dhcpv6-httpboot.ipxe;
+          }).overrideAttrs (oldAttrs: {
             patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
               ++ iPxePatches;
 

--- a/ipxe/dhcpv6-httpboot.ipxe
+++ b/ipxe/dhcpv6-httpboot.ipxe
@@ -1,0 +1,173 @@
+#!ipxe
+#
+# Robust DHCPv6 HTTP Boot Script
+# Retries forever until successful boot via DHCPv6-provided boot URI.
+# Automatically tries all available network interfaces.
+
+# ============================================================================
+# Configuration
+# ============================================================================
+set link_timeout:int32 10000
+set dhcp_timeout:int32 30000
+set chain_timeout:int32 30000
+set retry_delay:int32 5
+set attempt:int32 0
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+:start
+inc attempt
+echo
+echo iPXE DHCPv6 HTTP Boot
+echo Attempt ${attempt}
+
+# Start interface scan at net0
+set idx:int32 0
+
+# ============================================================================
+# Interface Loop - Try each interface in sequence
+# ============================================================================
+:try_next_interface
+set nic net${idx}
+
+# Check if this interface exists by testing if it has a MAC address
+isset ${${nic}/mac} || goto no_more_interfaces
+
+echo
+echo Trying interface: ${nic}
+echo    MAC: ${${nic}/mac}
+echo   Chip: ${${nic}/chip}
+
+# ============================================================================
+# Phase 1: Interface Reset
+# ============================================================================
+:reset_interface
+echo
+echo [${nic}] Phase 1: Resetting interface...
+ifclose ${nic} || echo Warning: ifclose returned error (ignorable)
+sleep 1
+
+# ============================================================================
+# Phase 2: Wait for Link
+# ============================================================================
+:wait_for_link
+echo [${nic}] Phase 2: Waiting for link-up (timeout: ${link_timeout}ms)...
+iflinkwait --timeout ${link_timeout} ${nic} || goto link_failed
+echo [${nic}] Link established
+goto configure_ipv6
+
+:link_failed
+echo [${nic}] No link detected, trying next interface
+ifclose ${nic} ||
+inc idx
+goto try_next_interface
+
+# ============================================================================
+# Phase 3: IPv6 Configuration
+# ============================================================================
+:configure_ipv6
+echo
+echo [${nic}] Phase 3: Configuring IPv6...
+
+# The "ipv6" configurator handles both SLAAC (for routing via Router Advertisements)
+# and DHCPv6 (for address and boot-uri option 59)
+echo [${nic}] Running IPv6 configuration for address and boot-uri...
+ifconf --configurator ipv6 --timeout ${dhcp_timeout} ${nic} || goto dhcp_failed
+echo [${nic}] IPv6 configuration successful
+goto verify_config
+
+:dhcp_failed
+echo [${nic}] IPv6 configuration failed, trying next interface
+ifstat ${nic}
+ifclose ${nic} ||
+inc idx
+goto try_next_interface
+
+# ============================================================================
+# Phase 4: Verify Configuration
+# ============================================================================
+:verify_config
+echo
+echo [${nic}] Phase 4: Verifying configuration...
+echo
+
+# Display current network state
+route
+echo
+echo [${nic}] Checking for boot-uri...
+
+# Verify we have a boot URI
+isset ${boot-uri} || goto no_boot_uri
+
+echo [${nic}] boot-uri: ${boot-uri}
+goto attempt_boot
+
+:no_boot_uri
+# Also check alternate variable names that some DHCP servers may use
+isset ${bootfile-url} && set boot-uri ${bootfile-url} && goto found_alt_uri ||
+isset ${filename} && set boot-uri ${filename} && goto found_alt_uri ||
+echo [${nic}] No boot-uri provided by DHCPv6 server, trying next interface
+ifclose ${nic} ||
+inc idx
+goto try_next_interface
+
+:found_alt_uri
+echo [${nic}] Found alternate boot URI variable
+echo [${nic}] boot-uri: ${boot-uri}
+
+# ============================================================================
+# Phase 5: Attempt Boot
+# ============================================================================
+:attempt_boot
+echo
+echo [${nic}] Phase 5: Attempting to chain-load from boot server...
+echo [${nic}] Target: ${boot-uri}
+echo
+
+# Reset retry delay on successful network config (not needed with fixed delay)
+
+# Chain to the boot URI
+# --autofree: Free memory used by this script after successful chain
+chain --autofree --timeout ${chain_timeout} ${boot-uri} || goto boot_failed
+
+# If chain returns (e.g., chained script ended without booting), treat as failure
+echo [${nic}] WARNING: Chained script returned without booting
+goto retry_all
+
+:boot_failed
+echo [${nic}] ERROR: Failed to chain-load from ${boot-uri}
+echo [${nic}] Error code: ${errno}
+echo [${nic}] Possible causes: server unreachable, invalid script, network issue
+
+# Try next interface in case this one has partial connectivity
+ifclose ${nic} ||
+inc idx
+goto try_next_interface
+
+# ============================================================================
+# No More Interfaces - Retry All
+# ============================================================================
+:no_more_interfaces
+echo
+echo No more interfaces to try, scanned net0 through net${idx}
+
+# Fall through to retry_all
+
+# ============================================================================
+# Retry Handler
+# ============================================================================
+:retry_all
+echo
+echo Boot attempt ${attempt} FAILED
+echo Retrying all interfaces in ${retry_delay} seconds...
+
+# Close any interfaces that might still be open
+set close_idx:int32 0
+:close_loop
+ifclose net${close_idx} ||
+inc close_idx
+iseq ${close_idx} ${idx} || goto close_loop
+
+sleep ${retry_delay}
+goto start

--- a/ipxe/dhcpv6-httpboot.ipxe
+++ b/ipxe/dhcpv6-httpboot.ipxe
@@ -73,6 +73,11 @@ echo [${nic}] Phase 3: Configuring IPv6...
 # The "ipv6" configurator handles both SLAAC (for routing via Router Advertisements)
 # and DHCPv6 (for address and boot-uri option 59)
 echo [${nic}] Running IPv6 configuration for address and boot-uri...
+
+clear boot-uri
+clear bootfile-url
+clear filename
+
 ifconf --configurator ipv6 --timeout ${dhcp_timeout} ${nic} || goto dhcp_failed
 echo [${nic}] IPv6 configuration successful
 goto verify_config
@@ -165,9 +170,13 @@ echo Retrying all interfaces in ${retry_delay} seconds...
 # Close any interfaces that might still be open
 set close_idx:int32 0
 :close_loop
-ifclose net${close_idx} ||
+
+set close_nic net${close_idx}
+isset ${${close_nic}/mac} || goto close_done
+ifclose ${close_nic}
 inc close_idx
-iseq ${close_idx} ${idx} || goto close_loop
+goto close_loop
+:close_done
 
 sleep ${retry_delay}
 goto start


### PR DESCRIPTION
This should catch issues with the network etc. that cause iPXE to fail and sends the system into the BIOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DHCPv6 HTTP boot script with automatic network-interface probing, configurable timeouts, retry logic, detailed progress/error messages, and chain-loading of discovered boot URIs.

* **Chores**
  * Updated packaging/configuration to integrate the new boot script into the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->