### PR TITLE
Expose the other remaining options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         if: ${{ success() || failure() }}
         run: nix develop --command codespell --ignore-words-list crate,pullrequest,pullrequests,ArchTypes --skip target,go.sum .
 
-      - name: Check nixpkgs-fmt formatting
+      - name: Check nixfmt formatting
         if: ${{ success() || failure() }}
-        run: git ls-files '*.nix' | nix develop --command xargs nixpkgs-fmt --check
+        run: git ls-files '*.nix' | nix develop --command xargs nixfmt --check
 
       - name: Check EditorConfig conformance
         if: ${{ success() || failure() }}

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769018530,
-        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
-        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
-        "revCount": 931542,
+        "lastModified": 1770115704,
+        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
+        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
+        "revCount": 939624,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.931542%2Brev-88d3861acdd3d2f0e361767018218e51810df8a1/019be60b-f6ea-74ec-ab74-e960f412a787/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.939624%2Brev-e6eae2ee2110f3d31110d5c222cd395303343b08/019c240d-29c9-709e-9b55-b0dc6858b20b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -136,7 +136,7 @@
                 enable = lib.mkEnableOption "DHCPv6MACd";
                 baseAddress = lib.mkOption {
                   type = lib.types.str;
-                  description = lib.mdDoc ''
+                  description = ''
                     The IPv6 address to start with when issuing IP addresses.
                     The prefix is assumed to be at least a /80.
                     The MAC address is simply concatenated onto the prefix.
@@ -144,70 +144,70 @@
                 };
                 interface = lib.mkOption {
                   type = lib.types.nullOr lib.types.str;
-                  description = lib.mdDoc ''
+                  description = ''
                     The name of the network interface to listen on.
                   '';
                 };
                 tftpListenAddress = lib.mkOption {
                   type = lib.types.str;
                   default = ":69";
-                  description = lib.mdDoc ''
+                  description = ''
                     The address to listen on for TFTP requests.
                   '';
                 };
                 httpListenAddress = lib.mkOption {
                   type = lib.types.str;
                   default = ":80";
-                  description = lib.mdDoc ''
+                  description = ''
                     The address to listen on for HTTP requests.
                   '';
                 };
                 httpsListenAddress = lib.mkOption {
                   type = lib.types.str;
                   default = ":443";
-                  description = lib.mdDoc ''
+                  description = ''
                     The address to listen on for HTTPS requests.
                   '';
                 };
                 dhcpv6ListenPort = lib.mkOption {
                   type = lib.types.int;
                   default = 547;
-                  description = lib.mdDoc ''
+                  description = ''
                     The port to listen on for DHCPv6 requests.
                   '';
                 };
                 httpBootUrlTemplate = lib.mkOption {
                   type = lib.types.str;
                   default = "";
-                  description = lib.mdDoc ''
+                  description = ''
                     `http://[{{.BaseAddress}}]/?mac={{.MAC}}&payload={{.Payload}}`
                   '';
                 };
                 httpBootRootCertificate = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
                   default = null;
-                  description = lib.mdDoc ''
+                  description = ''
                     Path to a root CA certificate to embed in the iPXE binary for HTTPS boot URL validation.
                     Required when httpBootUrlTemplate uses HTTPS and the server certificate is not signed by a well-known CA.
                   '';
                 };
                 netbootDirectory = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
-                  description = lib.mdDoc ''
+                  description = ''
                     `/netboot/mac`
                   '';
                 };
                 tlsCertFile = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
                   default = null;
-                  description = lib.mdDoc ''
+                  description = ''
                     Location of netboot TLS cert PEM.
                   '';
                 };
                 tlsKeyFile = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
                   default = null;
-                  description = lib.mdDoc ''
+                  description = ''
                     Location of netboot TLS key PEM.
                   '';
                 };
@@ -220,7 +220,7 @@
                     })
                     + "/ipxe.efi";
 
-                  description = lib.mdDoc ''
+                  description = ''
                     Path to the iPXE EFI binary for x86_64 to serve over TFTP.
                   '';
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -244,30 +244,40 @@
                     ProtectSystem = "strict";
                     ExecStart =
                       "${package}/bin/dhcpv6macd "
-                      + (lib.escapeShellArgs [
-                        "-base-address"
-                        cfg.baseAddress
-                        "-interface"
-                        cfg.interface
-                        "-tftp-listen-addr"
-                        cfg.tftpListenAddress
-                        "-http-listen-addr"
-                        cfg.httpListenAddress
-                        "-https-listen-addr"
-                        cfg.httpsListenAddress
-                        "-dhcpv6-listen-port"
-                        (toString cfg.dhcpv6ListenPort)
-                        "-http-boot-url-template"
-                        cfg.httpBootUrlTemplate
-                        "-tls-cert-file"
-                        cfg.tlsCertFile
-                        "-tls-key-file"
-                        cfg.tlsKeyFile
-                        "-netboot-dir"
-                        cfg.netbootDirectory
-                        "-ipxe-x86-64-efi"
-                        cfg.ipxeX8664Efi
-                      ]);
+                      + (lib.escapeShellArgs (
+                        [
+                          "-base-address"
+                          cfg.baseAddress
+                          "-interface"
+                          cfg.interface
+                          "-tftp-listen-addr"
+                          cfg.tftpListenAddress
+                          "-http-listen-addr"
+                          cfg.httpListenAddress
+                          "-https-listen-addr"
+                          cfg.httpsListenAddress
+                          "-dhcpv6-listen-port"
+                          (toString cfg.dhcpv6ListenPort)
+                          "-http-boot-url-template"
+                          cfg.httpBootUrlTemplate
+                          "-ipxe-x86-64-efi"
+                          cfg.ipxeX8664Efi
+                        ]
+                        ++ (lib.optionals (cfg.tlsCertFile != null) [
+
+                          "-tls-cert-file"
+                          cfg.tlsCertFile
+
+                        ])
+                        ++ (lib.optionals (cfg.tlsKeyFile != null) [
+                          "-tls-key-file"
+                          cfg.tlsKeyFile
+                        ])
+                        ++ (lib.optionals (cfg.netbootDirectory != null) [
+                          "-netboot-dir"
+                          cfg.netbootDirectory
+                        ])
+                      ));
                   };
                 };
               };

--- a/flake.nix
+++ b/flake.nix
@@ -306,6 +306,8 @@
             assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
           '';
         };
+
+        formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
     };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -193,6 +193,7 @@
                 };
                 netbootDirectory = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
+                  default = null;
                   description = ''
                     `/netboot/mac`
                   '';

--- a/flake.nix
+++ b/flake.nix
@@ -232,11 +232,8 @@
               in
               lib.mkIf cfg.enable {
                 networking.firewall.interfaces."${cfg.interface}" = {
-                  allowedUDPPorts = [
-                    547
-                    69
-                  ];
-                  allowedTCPPorts = [ 547 ];
+                  allowedUDPPorts = [ cfg.dhcpv6ListenPort ];
+                  allowedTCPPorts = [ cfg.dhcpv6ListenPort ];
                 };
 
                 systemd.services.dhcpv6macd = {

--- a/flake.nix
+++ b/flake.nix
@@ -105,18 +105,46 @@
             options = {
               services.detsys.dhcpv6macd = {
                 enable = lib.mkEnableOption "DHCPv6MACd";
-                interface = lib.mkOption {
-                  type = lib.types.nullOr lib.types.str;
-                  description = lib.mdDoc ''
-                    The name of the network interface to listen on.
-                  '';
-                };
                 baseAddress = lib.mkOption {
                   type = lib.types.str;
                   description = lib.mdDoc ''
                     The IPv6 address to start with when issuing IP addresses.
                     The prefix is assumed to be at least a /80.
                     The MAC address is simply concatenated onto the prefix.
+                  '';
+                };
+                interface = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  description = lib.mdDoc ''
+                    The name of the network interface to listen on.
+                  '';
+                };
+                tftpListenAddress = lib.mkOption {
+                  type = lib.types.str;
+                  default = ":69";
+                  description = lib.mdDoc ''
+                    The address to listen on for TFTP requests.
+                  '';
+                };
+                httpListenAddress = lib.mkOption {
+                  type = lib.types.str;
+                  default = ":80";
+                  description = lib.mdDoc ''
+                    The address to listen on for HTTP requests.
+                  '';
+                };
+                httpsListenAddress = lib.mkOption {
+                  type = lib.types.str;
+                  default = ":443";
+                  description = lib.mdDoc ''
+                    The address to listen on for HTTPS requests.
+                  '';
+                };
+                dhcpv6ListenPort = lib.mkOption {
+                  type = lib.types.int;
+                  default = 547;
+                  description = lib.mdDoc ''
+                    The port to listen on for DHCPv6 requests.
                   '';
                 };
                 httpBootUrlTemplate = lib.mkOption {
@@ -174,7 +202,7 @@
               lib.mkIf cfg.enable {
                 networking.firewall.interfaces."${cfg.interface}" = {
                   allowedUDPPorts = [ 547 69 ];
-                  allowedTCPPorts = [ 547 6315 ];
+                  allowedTCPPorts = [ 547 ];
                 };
 
                 systemd.services.dhcpv6macd = {
@@ -185,10 +213,18 @@
                     ProtectSystem = "strict";
                     ExecStart = "${package}/bin/dhcpv6macd "
                       + (lib.escapeShellArgs [
-                      "-interface"
-                      cfg.interface
                       "-base-address"
                       cfg.baseAddress
+                      "-interface"
+                      cfg.interface
+                      "-tftp-listen-addr"
+                      cfg.tftpListenAddress
+                      "-http-listen-addr"
+                      cfg.httpListenAddress
+                      "-https-listen-addr"
+                      cfg.httpsListenAddress
+                      "-dhcpv6-listen-port"
+                      (toString cfg.dhcpv6ListenPort)
                       "-http-boot-url-template"
                       cfg.httpBootUrlTemplate
                       "-tls-cert-file"

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
                   '';
                 };
                 interface = lib.mkOption {
-                  type = lib.types.nullOr lib.types.str;
+                  type = lib.types.str;
                   description = ''
                     The name of the network interface to listen on.
                   '';

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
                   eclint
                   go
                   go-tools
-                  nixpkgs-fmt
+                  nixfmt
                   just
                 ];
               };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,12 @@
   inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
   inputs.nix-filter.url = "github:numtide/nix-filter";
 
-  outputs = { self, nixpkgs, nix-filter }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix-filter,
+    }:
     let
 
       # to work with older version of flakes
@@ -15,7 +20,11 @@
       version = builtins.substring 0 8 lastModifiedDate;
 
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -29,79 +38,99 @@
       ];
     in
     {
-      devShells = forAllSystems
-        (system:
-          let
-            pkgs = nixpkgsFor.${system};
-          in
-          {
-            default = pkgs.mkShell
-              {
-                buildInputs = with pkgs; [
-                  codespell
-                  eclint
-                  go
-                  go-tools
-                  nixfmt
-                  just
-                ];
-              };
-          });
-
-      lib = {
-        mkiPXE = { system, certBundle ? null }:
-          (nixpkgsFor.${system}.ipxe.override {
-            embedScript = ./ipxe/dhcpv6-httpboot.ipxe;
-          }).overrideAttrs (oldAttrs: {
-            patches = (if oldAttrs ? patches then oldAttrs.patches else [ ])
-              ++ iPxePatches;
-
-            makeFlags = oldAttrs.makeFlags ++ (nixpkgs.lib.optional (certBundle != null)
-              ''TRUST=${certBundle}'');
-          });
-      };
-
-      # Provide some binary packages for selected system types.
-      packages = forAllSystems (system:
+      devShells = forAllSystems (
+        system:
         let
           pkgs = nixpkgsFor.${system};
         in
-        ({
-          default = pkgs.buildGoModule {
-            pname = "dhcpv6macd";
-            inherit version;
-
-            src = nix-filter.lib {
-              root = ./.;
-              include = [
-                "go.mod"
-                "go.sum"
-                (nix-filter.lib.matchExt "go")
-              ];
-            };
-
-            # This hash locks the dependencies of this package. It is
-            # necessary because of how Go requires network access to resolve
-            # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
-            # details. Normally one can build with a fake sha256 and rely on native Go
-            # mechanisms to tell you what the hash should be or determine what
-            # it should be "out-of-band" with other tooling (eg. gomod2nix).
-            # To begin with it is recommended to set this, but one must
-            # remember to bump this hash when your dependencies change.
-            #vendorSha256 = pkgs.lib.fakeSha256;
-
-            goSum = ./go.sum;
-            vendorHash = "sha256-7H8eyzGHrvyDXCtB39u42mqn682qaE8Q64T4ImyWCpY=";
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              codespell
+              eclint
+              go
+              go-tools
+              nixfmt
+              just
+            ];
           };
-        } // (if (system == "aarch64-darwin") then { } else {
-          iPXE = self.lib.mkiPXE { inherit system; };
-        })
-        ));
+        }
+      );
+
+      lib = {
+        mkiPXE =
+          {
+            system,
+            certBundle ? null,
+          }:
+          (nixpkgsFor.${system}.ipxe.override {
+            embedScript = ./ipxe/dhcpv6-httpboot.ipxe;
+          }).overrideAttrs
+            (oldAttrs: {
+              patches = (if oldAttrs ? patches then oldAttrs.patches else [ ]) ++ iPxePatches;
+
+              makeFlags = oldAttrs.makeFlags ++ (nixpkgs.lib.optional (certBundle != null) "TRUST=${certBundle}");
+            });
+      };
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        (
+          {
+            default = pkgs.buildGoModule {
+              pname = "dhcpv6macd";
+              inherit version;
+
+              src = nix-filter.lib {
+                root = ./.;
+                include = [
+                  "go.mod"
+                  "go.sum"
+                  (nix-filter.lib.matchExt "go")
+                ];
+              };
+
+              # This hash locks the dependencies of this package. It is
+              # necessary because of how Go requires network access to resolve
+              # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
+              # details. Normally one can build with a fake sha256 and rely on native Go
+              # mechanisms to tell you what the hash should be or determine what
+              # it should be "out-of-band" with other tooling (eg. gomod2nix).
+              # To begin with it is recommended to set this, but one must
+              # remember to bump this hash when your dependencies change.
+              #vendorSha256 = pkgs.lib.fakeSha256;
+
+              goSum = ./go.sum;
+              vendorHash = "sha256-7H8eyzGHrvyDXCtB39u42mqn682qaE8Q64T4ImyWCpY=";
+            };
+          }
+          // (
+            if (system == "aarch64-darwin") then
+              { }
+            else
+              {
+                iPXE = self.lib.mkiPXE { inherit system; };
+              }
+          )
+        )
+      );
 
       nixosModules = {
-        dhcpv6macd = { pkgs, config, lib, ... }:
-          let cfg = config.services.detsys.dhcpv6macd;
-          in {
+        dhcpv6macd =
+          {
+            pkgs,
+            config,
+            lib,
+            ...
+          }:
+          let
+            cfg = config.services.detsys.dhcpv6macd;
+          in
+          {
             options = {
               services.detsys.dhcpv6macd = {
                 enable = lib.mkEnableOption "DHCPv6MACd";
@@ -184,10 +213,12 @@
                 };
                 ipxeX8664Efi = lib.mkOption {
                   type = lib.types.nullOr lib.types.path;
-                  default = (self.lib.mkiPXE {
-                    system = "x86_64-linux";
-                    certBundle = cfg.httpBootRootCertificate;
-                  }) + "/ipxe.efi";
+                  default =
+                    (self.lib.mkiPXE {
+                      system = "x86_64-linux";
+                      certBundle = cfg.httpBootRootCertificate;
+                    })
+                    + "/ipxe.efi";
 
                   description = lib.mdDoc ''
                     Path to the iPXE EFI binary for x86_64 to serve over TFTP.
@@ -201,7 +232,10 @@
               in
               lib.mkIf cfg.enable {
                 networking.firewall.interfaces."${cfg.interface}" = {
-                  allowedUDPPorts = [ 547 69 ];
+                  allowedUDPPorts = [
+                    547
+                    69
+                  ];
                   allowedTCPPorts = [ 547 ];
                 };
 
@@ -211,31 +245,32 @@
                     DynamicUser = true;
                     AmbientCapabilities = "CAP_NET_BIND_SERVICE";
                     ProtectSystem = "strict";
-                    ExecStart = "${package}/bin/dhcpv6macd "
+                    ExecStart =
+                      "${package}/bin/dhcpv6macd "
                       + (lib.escapeShellArgs [
-                      "-base-address"
-                      cfg.baseAddress
-                      "-interface"
-                      cfg.interface
-                      "-tftp-listen-addr"
-                      cfg.tftpListenAddress
-                      "-http-listen-addr"
-                      cfg.httpListenAddress
-                      "-https-listen-addr"
-                      cfg.httpsListenAddress
-                      "-dhcpv6-listen-port"
-                      (toString cfg.dhcpv6ListenPort)
-                      "-http-boot-url-template"
-                      cfg.httpBootUrlTemplate
-                      "-tls-cert-file"
-                      cfg.tlsCertFile
-                      "-tls-key-file"
-                      cfg.tlsKeyFile
-                      "-netboot-dir"
-                      cfg.netbootDirectory
-                      "-ipxe-x86-64-efi"
-                      cfg.ipxeX8664Efi
-                    ]);
+                        "-base-address"
+                        cfg.baseAddress
+                        "-interface"
+                        cfg.interface
+                        "-tftp-listen-addr"
+                        cfg.tftpListenAddress
+                        "-http-listen-addr"
+                        cfg.httpListenAddress
+                        "-https-listen-addr"
+                        cfg.httpsListenAddress
+                        "-dhcpv6-listen-port"
+                        (toString cfg.dhcpv6ListenPort)
+                        "-http-boot-url-template"
+                        cfg.httpBootUrlTemplate
+                        "-tls-cert-file"
+                        cfg.tlsCertFile
+                        "-tls-key-file"
+                        cfg.tlsKeyFile
+                        "-netboot-dir"
+                        cfg.netbootDirectory
+                        "-ipxe-x86-64-efi"
+                        cfg.ipxeX8664Efi
+                      ]);
                   };
                 };
               };
@@ -243,71 +278,71 @@
       };
 
       checks.x86_64-linux.package = self.packages.x86_64-linux.default;
-      checks.x86_64-linux.nixostest-basic = (import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; }).simpleTest
-        {
-          name = "basic";
-          nodes.router = {
-            imports = [
-              self.nixosModules.dhcpv6macd
-            ];
+      checks.x86_64-linux.nixostest-basic =
+        (import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "x86_64-linux"; }).simpleTest
+          {
+            name = "basic";
+            nodes.router = {
+              imports = [
+                self.nixosModules.dhcpv6macd
+              ];
 
-            services.detsys.dhcpv6macd = {
-              enable = true;
-              interface = "eth1";
-              baseAddress = "fd19:287e:c5a0:4931::";
-              netbootDirectory = "/netboot/mac";
-              ipxeX8664Efi = builtins.toFile "ipxe.efi" "its-ipxe\n";
-            };
+              services.detsys.dhcpv6macd = {
+                enable = true;
+                interface = "eth1";
+                baseAddress = "fd19:287e:c5a0:4931::";
+                netbootDirectory = "/netboot/mac";
+                ipxeX8664Efi = builtins.toFile "ipxe.efi" "its-ipxe\n";
+              };
 
-            networking.useNetworkd = true;
-            systemd.network.networks = {
-              "10-ds-macnet" = {
-                matchConfig.Name = "eth1";
+              networking.useNetworkd = true;
+              systemd.network.networks = {
+                "10-ds-macnet" = {
+                  matchConfig.Name = "eth1";
 
-                address = [
-                  "fd19:287e:c5a0:4931::/64"
-                  "fe80::1/64"
-                ];
+                  address = [
+                    "fd19:287e:c5a0:4931::/64"
+                    "fe80::1/64"
+                  ];
 
-                networkConfig = {
-                  DHCPServer = true;
-                  IPv6SendRA = true;
+                  networkConfig = {
+                    DHCPServer = true;
+                    IPv6SendRA = true;
+                  };
+                  ipv6SendRAConfig.Managed = true;
+                  linkConfig.RequiredForOnline = false;
                 };
-                ipv6SendRAConfig.Managed = true;
-                linkConfig.RequiredForOnline = false;
               };
             };
-          };
 
-          nodes.client = {
-            systemd.network.networks."40-eth1" = {
-              dhcpV6Config.DUIDType = "link-layer";
-            };
-            networking = {
-              useNetworkd = true;
-              useDHCP = false;
-              interfaces.eth1 = {
-                useDHCP = true;
-                macAddress = "02:de:ad:be:ef:01";
+            nodes.client = {
+              systemd.network.networks."40-eth1" = {
+                dhcpV6Config.DUIDType = "link-layer";
+              };
+              networking = {
+                useNetworkd = true;
+                useDHCP = false;
+                interfaces.eth1 = {
+                  useDHCP = true;
+                  macAddress = "02:de:ad:be:ef:01";
+                };
               };
             };
+
+            testScript = ''
+              router.wait_for_unit("network.target")
+              router.wait_for_unit("dhcpv6macd.service")
+              router.succeed("systemd-cat ip addr")
+
+
+              client.wait_for_unit("network.target")
+              client.succeed("sleep 5")
+
+              eth1_addrs = client.succeed("ip -6 addr show eth1")
+              assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
+            '';
           };
 
-          testScript = ''
-            router.wait_for_unit("network.target")
-            router.wait_for_unit("dhcpv6macd.service")
-            router.succeed("systemd-cat ip addr")
-
-
-            client.wait_for_unit("network.target")
-            client.succeed("sleep 5")
-
-            eth1_addrs = client.succeed("ip -6 addr show eth1")
-            assert "fd19:287e:c5a0:4931:0:2de:adbe:ef01" in eth1_addrs, "Did not find expected client IPv6 addr"
-          '';
-        };
-
-        formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
     };
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public listener options for TFTP, HTTP (":80"), HTTPS (":443"), DHCPv6 listen port (default 547) and explicit baseAddress; exposed a cross-system nixfmt formatter.
* **Bug Fixes**
  * Service start-up now assembles and respects ordered listen flags and conditional TLS options; firewall rules use the configured DHCPv6 port.
* **Chores**
  * CI formatting check renamed to nixfmt; packaging/dev-shell naming and several config blocks reformatted for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->